### PR TITLE
The big update

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var settings = require('./package.json');
 var util = require('./lib/util');
 
 var argv = require('minimist')(process.argv, {
-    string: ["input", "output", "in-network", "in-address", "tokens", "map", "coords", "xy"],
+    string: ["input", "output", "in-network", "in-address", "tokens", "map", "coords", "xy", "raw"],
     integer: ["workers", "zoom"],
     boolean: ["help", "debug"],
     alias: {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var argv = require('minimist')(process.argv, {
     integer: ["workers", "zoom"],
     boolean: ["help", "debug"],
     alias: {
+        "in-address": "in-addresses",
         "version": "v",
         "output":  "o",
         "input":   "i"

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var map = require('./lib/map');
 var convert = require('./lib/convert');
 var settings = require('./package.json');
 var util = require('./lib/util');
+var name = require('./lib/name');
 
 var argv = require('minimist')(process.argv, {
     string: ["input", "output", "in-network", "in-address", "tokens", "map", "coords", "xy", "raw"],
@@ -35,6 +36,7 @@ switch (argv._[2]) {
     case ("util"):
         util(argv);
         break;
+    case ("name"):
     case ("map"):
         map(argv);
         break;

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -2,7 +2,7 @@ module.exports = cluster;
 
 var turf = require('turf');
 
-//Accepts a feature collection and outputs 
+//Accepts a feature collection and outputs
 //FeatureCollections of MultiPoint geometries - one for each identically named road
 function cluster(feats) {
     var featMap = {};
@@ -43,7 +43,12 @@ function cluster(feats) {
             var feat = turf.combine(turf.featurecollection(featMap[streets[i]]))
             if (feat.type === 'FeatureCollection') feat = feat.features[0];
             feat.properties.street = featMap[streets[i]][0].properties.street
-            feat.properties['carmen:text'] = featMap[streets[i]][0].properties['carmen:text']
+
+            if (feat.properties.street.length === 0) {
+                feat.properties['carmen:text'] = '';
+            } else {
+                feat.properties['carmen:text'] = featMap[streets[i]][0].properties['carmen:text']
+            }
         }
 
         featCluster.features.push(feat);

--- a/lib/map.js
+++ b/lib/map.js
@@ -89,7 +89,7 @@ module.exports = function(argv) {
             name: 'Streets',
             mbtiles: path.resolve(__dirname, '..', argv['in-network'])
         }],
-        map: __dirname+'/worker.js'
+        map: argv._[2] === 'map' ? __dirname+'/worker.js' : __dirname+'/name.js'
     }).on('start', function() {
         console.log('Beginning Processing');
     }).on('reduce', function(err, tile) { 

--- a/lib/map/qa-tiles.js
+++ b/lib/map/qa-tiles.js
@@ -35,7 +35,6 @@ module.exports.map = function(tile, argv) {
                 'primary',
                 'secondary',
                 'tertiary',
-                'unclassified',
                 'residential',
                 'living_street',
                 'road'

--- a/lib/map/qa-tiles.js
+++ b/lib/map/qa-tiles.js
@@ -42,7 +42,7 @@ module.exports.map = function(tile, argv) {
             ];
 
             //Eliminate all highway types not on accepted list
-            if (accepted.indedxOf(feat.properties.highway) === -1) continue;
+            if (accepted.indexOf(feat.properties.highway) === -1) continue;
         } else {
             if (!feat.properties.name) continue;
         }

--- a/lib/map/qa-tiles.js
+++ b/lib/map/qa-tiles.js
@@ -5,7 +5,7 @@
 //This module maps streets from http://osmlab.github.io/osm-qa-tiles/ into the proper format
 //Addresses must be provided from another source
 
-module.exports.map = function(tile) {
+module.exports.map = function(tile, argv) {
 
     if (!tile.Streets.osm) {
         tile.Streets = {};
@@ -27,8 +27,10 @@ module.exports.map = function(tile) {
         //Skip non-highways
         if (!feat.properties.highway) continue;
 
-        //Can't match without a name
-        if (!feat.properties.name) continue;
+        //Can't match without a name unless in name matching mode
+        if (argv._[2] === 'name') {
+            if (!feat.properties.name) continue;
+        }
 
         streets.features.push({
             type: 'Feature',

--- a/lib/map/qa-tiles.js
+++ b/lib/map/qa-tiles.js
@@ -29,6 +29,21 @@ module.exports.map = function(tile, argv) {
 
         //Can't match without a name unless in name matching mode
         if (argv._[2] === 'name') {
+            var accepted = [
+                'motorway',
+                'trunk',
+                'primary',
+                'secondary',
+                'tertiary',
+                'unclassified',
+                'residential',
+                'living_street',
+                'road'
+            ];
+
+            //Eliminate all highway types not on accepted list
+            if (accepted.indedxOf(feat.properties.highway) === -1) continue;
+        } else {
             if (!feat.properties.name) continue;
         }
 

--- a/lib/map/qa-tiles.js
+++ b/lib/map/qa-tiles.js
@@ -42,8 +42,8 @@ module.exports.map = function(tile, argv) {
 
             //Eliminate all highway types not on accepted list
             if (accepted.indexOf(feat.properties.highway) === -1) continue;
-        } else {
-            if (!feat.properties.name) continue;
+        } else if (!feat.properties.name) {
+            continue;
         }
 
         streets.features.push({

--- a/lib/name.js
+++ b/lib/name.js
@@ -1,5 +1,6 @@
 var turf = require('turf');
 var path = require('path');
+var tokenize = require('./tokenize');
 
 module.exports = function(data, xyz, writeData, done) {
     if (!global.mapOptions) global.mapOptions = {};
@@ -23,4 +24,19 @@ module.exports = function(data, xyz, writeData, done) {
         return done(null, 'dumped: ' + xyz.join(','));
     }
 
+    var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
+    var streets = cluster(tokenizeFeat(data.Streets.streets));
+}
+
+function tokenizeFeat(feats) {
+    feats.features = feats.features.map(function(feat) {
+        if (feat.properties.street) {
+            feat.properties['carmen:text'] = feat.properties.street;
+            feat.properties.street = tokenize(feat.properties.street, global.mapOptions);
+        } else {
+            feat.properties.street = [];
+        }
+        return feat;
+    });
+    return feats;
 }

--- a/lib/name.js
+++ b/lib/name.js
@@ -29,11 +29,8 @@ module.exports = function(data, xyz, writeData, done) {
     var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
     var streets = cluster(tokenizeFeat(data.Streets.streets));
 
-    var noName = {
-        type: 'FeatureCollection',
-        features: []
-    };
-    
+    var bugs = 0; //Running tally of number of problematic geoms
+
     var filterStr = {
         type: 'FeatureCollection',
         features: []
@@ -47,14 +44,33 @@ module.exports = function(data, xyz, writeData, done) {
             for (ls_it = 0; ls_it < str.geometry.coordinates.length; ls_it++) {
                 var ls = str.geometry.coordinates[ls_it];
 
-                noName.features.push({
+                var feat = {
                     type: 'Feature',
                     properties: str.properties,
                     geometry: {
                         type: 'LineString',
                         coordinates: ls
                     }
-                });
+                };
+
+                if (global.mapOptions.debug) {
+                    var closest = closestCluster(feat, addresses);
+
+                    if (closest) {
+                        var featCollect = {
+                            type: 'FeatureCollection',
+                            features: closest.concat([feat])
+                        }
+
+                        writeData(JSON.stringify(featCollect) + '\n');
+                        bugs++;
+                    }
+                } else {
+                    writeData(JSON.stringify(feat) + '\n');
+                    bugs++;
+                }
+
+
                 continue;
             }
         }
@@ -68,13 +84,7 @@ module.exports = function(data, xyz, writeData, done) {
         }
     }
 
-    var results = [];
-
-    noName.features.forEach(function (str) {
-        writeData(JSON.stringify(str) + '\n');
-    });
-
-    return done(null, 'Finished - ' + results.length + ' matched');
+    return done(null, 'Finished - ' + bugs + ' matched');
 }
 
 function tokenizeFeat(feats) {
@@ -88,4 +98,54 @@ function tokenizeFeat(feats) {
         return feat;
     });
     return feats;
+}
+
+function closestCluster(str, addresses) {
+    if (str.geometry.type !== 'LineString') return null; //I only deal with linestrings
+
+    //Don't really like circles either
+    if (_.isEqual(str.geometry.coordinates[0], str.geometry.coordinates[str.geometry.coordinates.length-1])) return null;
+
+    var closest = [];
+
+    for (var addr_it = 0; addr_it < addresses.features.length; addr_it++) {
+        var addr = addresses.features[addr_it];       
+ 
+        for (var pt_it = 0; pt_it < addr.geometry.coordinates.length; pt_it++) {
+            var dist = turf.distance(
+                turf.pointOnLine(str, turf.point(addr.geometry.coordinates[pt_it])),
+                turf.point(addr.geometry.coordinates[pt_it]),
+                'kilometers'
+            );
+            if (dist <= 0.200) { //I don't really care about addresses further away than this
+                closest.push({
+                    dist: dist,
+                    pt: addr.geometry.coordinates[pt_it],
+                    cluster: addr_it
+                });
+            }
+        }
+    }
+
+    closest.sort(function(a, b) {
+        return a.dist - b.dist;
+    });
+
+    if (closest.length > 0) {
+        var current = closest[0].cluster;
+        var res = [addresses.features[current]]
+        for (var closest_it = 1; closest_it < closest.length; closest_it++) {
+            if (current === closest[closest_it].cluster) continue;
+
+            res.push(addresses.features[closest[closest_it].cluster]);
+            break;
+        }
+
+        if (res[0]) res[0].properties['marker-color'] = '#008000';
+        if (res[1]) res[1].properties['marker-color'] = '#003200';
+
+        return res;
+    } else {
+        return null;
+    }
 }

--- a/lib/name.js
+++ b/lib/name.js
@@ -2,6 +2,7 @@ var turf = require('turf');
 var path = require('path');
 var cluster = require('./cluster');
 var tokenize = require('./tokenize');
+var _ = require('lodash');
 
 module.exports = function(data, xyz, writeData, done) {
     if (!global.mapOptions) global.mapOptions = {};
@@ -27,6 +28,19 @@ module.exports = function(data, xyz, writeData, done) {
 
     var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
     var streets = cluster(tokenizeFeat(data.Streets.streets));
+
+
+    for (var addr_it = 0; addr_it < addresses.features.length; addr_it++) {
+        var addr = addresses.features[addr_it];
+
+        for (var str_it = 0; str_it < streets.features.length; str_it++) {
+            var str = streets.features[str_it];
+
+            //If the street names are the same - eliminate
+            if (_.isEqual(addr.properties.street, str.properties.street)) continue;
+
+        }
+    }
 
     var results = [];
 

--- a/lib/name.js
+++ b/lib/name.js
@@ -29,20 +29,39 @@ module.exports = function(data, xyz, writeData, done) {
     var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
     var streets = cluster(tokenizeFeat(data.Streets.streets));
 
+    var noName = {
+        type: 'FeatureCollection',
+        features: []
+    };
+    
+    var filterStr = {
+        type: 'FeatureCollection',
+        features: []
+    };
 
-    for (var addr_it = 0; addr_it < addresses.features.length; addr_it++) {
-        var addr = addresses.features[addr_it];
+    //Iterate through streets and bin based on error type:
+    for (var str_it = 0; str_it < streets.features.length; str_it++) {
+        var str = streets.features[str_it];
+        
+        if (str.properties.street.length === 0) {
+            noName.features.push(str);
+            continue;
+        }
 
-        for (var str_it = 0; str_it < streets.features.length; str_it++) {
-            var str = streets.features[str_it];
+        for (var addr_it = 0; addr_it < addresses.features.length; addr_it++) {
+            var addr = addresses.features[addr_it];
 
             //If the street names are the same - eliminate
             if (_.isEqual(addr.properties.street, str.properties.street)) continue;
-
+            else filterStr.features.push(str);
         }
     }
 
     var results = [];
+
+    noName.features.forEach(function (str) {
+        writeData(JSON.stringify(str) + '\n');
+    });
 
     return done(null, 'Finished - ' + results.length + ' matched');
 }

--- a/lib/name.js
+++ b/lib/name.js
@@ -20,7 +20,7 @@ module.exports = function(data, xyz, writeData, done) {
     if (!data.Streets.streets || !data.Streets.streets.features || data.Streets.streets.features.length === 0) return done(null, 'No street data in: ' + xyz.join(','));
 
     if (global.mapOptions.raw === 'addresses') {
-        data.Addresses.addresses.features.forEach(function (addr) {
+        data.Addresses.addresses.features.forEach(function(addr) {
             writeData(JSON.stringify(addr) + '\n');
         });
         return done(null, 'dumped: ' + xyz.join(','));

--- a/lib/name.js
+++ b/lib/name.js
@@ -1,5 +1,6 @@
 var turf = require('turf');
 var path = require('path');
+var cluster = require('./cluster');
 var tokenize = require('./tokenize');
 
 module.exports = function(data, xyz, writeData, done) {
@@ -7,7 +8,7 @@ module.exports = function(data, xyz, writeData, done) {
 
     if (global.mapOptions.map) {
         remap = require(__dirname + '/../' + global.mapOptions.map);
-        data = remap.map(data);
+        data = remap.map(data, global.mapOptions);
     }
 
     if (!global.mapOptions.zoom) {
@@ -26,6 +27,10 @@ module.exports = function(data, xyz, writeData, done) {
 
     var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
     var streets = cluster(tokenizeFeat(data.Streets.streets));
+
+    var results = [];
+
+    return done(null, 'Finished - ' + results.length + ' matched');
 }
 
 function tokenizeFeat(feats) {

--- a/lib/name.js
+++ b/lib/name.js
@@ -44,8 +44,19 @@ module.exports = function(data, xyz, writeData, done) {
         var str = streets.features[str_it];
         
         if (str.properties.street.length === 0) {
-            noName.features.push(str);
-            continue;
+            for (ls_it = 0; ls_it < str.geometry.coordinates.length; ls_it++) {
+                var ls = str.geometry.coordinates[ls_it];
+
+                noName.features.push({
+                    type: 'Feature',
+                    properties: str.properties,
+                    geometry: {
+                        type: 'LineString',
+                        coordinates: ls
+                    }
+                });
+                continue;
+            }
         }
 
         for (var addr_it = 0; addr_it < addresses.features.length; addr_it++) {

--- a/lib/name.js
+++ b/lib/name.js
@@ -1,0 +1,26 @@
+var turf = require('turf');
+var path = require('path');
+
+module.exports = function(data, xyz, writeData, done) {
+    if (!global.mapOptions) global.mapOptions = {};
+
+    if (global.mapOptions.map) {
+        remap = require(__dirname + '/../' + global.mapOptions.map);
+        data = remap.map(data);
+    }
+
+    if (!global.mapOptions.zoom) {
+        global.mapOptions.zoom =  xyz[2];
+    }
+
+    if (!data.Addresses.addresses || !data.Addresses.addresses.features || data.Addresses.addresses.features.length === 0) return done(null, 'No address data in: ' + xyz.join(','));
+    if (!data.Streets.streets || !data.Streets.streets.features || data.Streets.streets.features.length === 0) return done(null, 'No street data in: ' + xyz.join(','));
+
+    if (global.mapOptions.raw === 'addresses') {
+        data.Addresses.addresses.features.forEach(function (addr) {
+            writeData(JSON.stringify(addr) + '\n');
+        });
+        return done(null, 'dumped: ' + xyz.join(','));
+    }
+
+}

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -26,7 +26,7 @@ module.exports = function(data, xyz, writeData, done) {
     if (!data.Streets.streets || !data.Streets.streets.features || data.Streets.streets.features.length === 0) return done(null, 'No street data in: ' + xyz.join(','));
 
     if (global.mapOptions.raw === 'addresses') {
-        data.Addresses.addresses.features.forEach(function (addr) {
+        data.Addresses.addresses.features.forEach(function(addr) {
             writeData(JSON.stringify(addr) + '\n');
         });
         return done(null, 'dumped: ' + xyz.join(','));

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -25,6 +25,13 @@ module.exports = function(data, xyz, writeData, done) {
     if (!data.Addresses.addresses || !data.Addresses.addresses.features || data.Addresses.addresses.features.length === 0) return done(null, 'No address data in: ' + xyz.join(','));
     if (!data.Streets.streets || !data.Streets.streets.features || data.Streets.streets.features.length === 0) return done(null, 'No street data in: ' + xyz.join(','));
 
+    if (global.mapOptions.raw === 'addresses') {
+        data.Addresses.addresses.features.forEach(function (addr) {
+            writeData(JSON.stringify(addr) + '\n');
+        });
+        return done(null, 'dumped: ' + xyz.join(','));
+    }
+
     var addresses = cluster(tokenizeFeat(data.Addresses.addresses));
     var streets = explode(cluster(tokenizeFeat(data.Streets.streets)));
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -15,7 +15,7 @@ module.exports = function(data, xyz, writeData, done) {
 
     if (global.mapOptions.map) {
         remap = require(__dirname + '/../' + global.mapOptions.map);
-        data = remap.map(data);
+        data = remap.map(data, global.mapOptions);
     }
 
     if (!global.mapOptions.zoom) {


### PR DESCRIPTION
Fairly large update to fxnality

- Add `name` mode which will dump unnamed streets, when combined with the `--debug` flag it will also include the 2 address clusters which have the highest probability of having the correct street name.

- Add `--raw <TYPE>` mode which allows dumping of address data in a given tile (works for `map` and `name` mode ToDo allow `streets` & `*`)

- Add plurals as aliases so I have to check my own docs less