### PR TITLE
Make sure parity happens

### DIFF
--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -108,13 +108,49 @@ function interpolize(street, address, argv) {
     parity.totall = parity.lo + parity.le;
     parity.totalr = parity.ro + parity.re;
 
-    var lparity;
-    var rparity;
+    var lparity, rparity;
 
-    if (parity.lo / parity.totall > 0.80) lparity = 'O';
-    if (parity.le / parity.totall > 0.80) lparity = 'E';
-    if (parity.ro / parity.totalr > 0.80) rparity = 'O';
-    if (parity.re / parity.totalr > 0.80) rparity = 'E';
+    if (parity.lo / parity.totall > 0.70) lparity = 'O';
+    if (parity.le / parity.totall > 0.70) lparity = 'E';
+    if (parity.ro / parity.totalr > 0.70) rparity = 'O';
+    if (parity.re / parity.totalr > 0.70) rparity = 'E';
+
+    //At lease some parity is needed to make this work
+    if (!rparity) {
+        if (result.rstart % 2 === 0 && result.rend % 2 === 0) {
+            rparity = 'E';
+        } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
+            rparity = 'O';
+        } else { //This is completely arbitrary - in the US odd are usually left/even right
+            rparity = 'E';
+        }
+    }
+
+    if (rparity === 'E') {
+        if (result.rstart % 2 !== 0) result.rstart++;
+        if (result.rend % 2 !== 0) result.rend++;
+    } else {
+        if (result.rstart % 2 !== 1) result.rstart++;
+        if (result.rend % 2 !== 1) result.rend++;
+    }
+
+    if (!lparity) {
+        if (result.lstart % 2 === 0 && result.lend % 2 === 0) {
+            lparity = 'E';
+        } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
+            lparity = 'O';
+        } else {
+
+        }
+    }
+
+    if (lparity === 'E') {
+        if (result.lstart % 2 !== 0) result.lstart++;
+        if (result.lend % 2 !== 0) result.lend++;
+    } else {
+        if (result.lstart % 2 !== 1) result.lstart++;
+        if (result.lend % 2 !== 1) result.lend++;
+    }
 
     //Setup final results
     street.id = parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100));

--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -110,46 +110,56 @@ function interpolize(street, address, argv) {
 
     var lparity, rparity;
 
-    if (parity.lo / parity.totall > 0.70) lparity = 'O';
-    if (parity.le / parity.totall > 0.70) lparity = 'E';
-    if (parity.ro / parity.totalr > 0.70) rparity = 'O';
-    if (parity.re / parity.totalr > 0.70) rparity = 'E';
+    if (!result.rstart && result.rend) result.rstart = result.rend;
+    if (!result.rend && result.rstart) result.rend = result.rstart;
+    if (!result.lstart && result.lend) result.lstart = result.lend;
+    if (!result.lend && result.lstart) result.lend = result.lstart;
 
-    //At lease some parity is needed to make this work
-    if (!rparity) {
-        if (result.rstart % 2 === 0 && result.rend % 2 === 0) {
-            rparity = 'E';
-        } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
-            rparity = 'O';
-        } else { //This is completely arbitrary - in the US odd are usually left/even right
-            rparity = 'E';
+    if (result.rstart && result.rend) {
+        if (parity.ro / parity.totalr > 0.70) rparity = 'O';
+        if (parity.re / parity.totalr > 0.70) rparity = 'E';
+
+        //At lease some parity is needed to make this work
+        if (!rparity) {
+            if (result.rstart % 2 === 0 && result.rend % 2 === 0) {
+                rparity = 'E';
+            } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
+                rparity = 'O';
+            } else { //This is completely arbitrary - in the US odd are usually left/even right
+                rparity = 'E';
+            }
         }
-    }
 
-    if (rparity === 'E') {
-        if (result.rstart % 2 !== 0) result.rstart++;
-        if (result.rend % 2 !== 0) result.rend++;
-    } else {
-        if (result.rstart % 2 !== 1) result.rstart++;
-        if (result.rend % 2 !== 1) result.rend++;
-    }
-
-    if (!lparity) {
-        if (result.lstart % 2 === 0 && result.lend % 2 === 0) {
-            lparity = 'E';
-        } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
-            lparity = 'O';
+        if (rparity === 'E') {
+            if (result.rstart % 2 !== 0) result.rstart++;
+            if (result.rend % 2 !== 0) result.rend++;
         } else {
-            lparity = 'O';
+            if (result.rstart % 2 !== 1) result.rstart++;
+            if (result.rend % 2 !== 1) result.rend++;
         }
     }
+    
+    if (result.lstart && result.lend) {
+        if (parity.lo / parity.totall > 0.70) lparity = 'O';
+        if (parity.le / parity.totall > 0.70) lparity = 'E';
 
-    if (lparity === 'E') {
-        if (result.lstart % 2 !== 0) result.lstart++;
-        if (result.lend % 2 !== 0) result.lend++;
-    } else {
-        if (result.lstart % 2 !== 1) result.lstart++;
-        if (result.lend % 2 !== 1) result.lend++;
+        if (!lparity) {
+            if (result.lstart % 2 === 0 && result.lend % 2 === 0) {
+                lparity = 'E';
+            } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
+                lparity = 'O';
+            } else {
+                lparity = 'O';
+            }
+        }
+
+        if (lparity === 'E') {
+            if (result.lstart % 2 !== 0) result.lstart++;
+            if (result.lend % 2 !== 0) result.lend++;
+        } else {
+            if (result.lstart % 2 !== 1) result.lstart++;
+            if (result.lend % 2 !== 1) result.lend++;
+        }
     }
 
     //Setup final results

--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -140,7 +140,7 @@ function interpolize(street, address, argv) {
         } else if (result.rstart % 2 === 1 && result.rend % 2 === 1) {
             lparity = 'O';
         } else {
-
+            lparity = 'O';
         }
     }
 

--- a/test/worker-fixtures.test.js
+++ b/test/worker-fixtures.test.js
@@ -94,17 +94,25 @@ test('worker - fixtures', function(t) {
                         resPass = false;
 
                         for (var res_it = 0; res_it < res.length; res_it++) {
-                            if (
-                                res[res_it].properties['carmen:lparity'] === streetFixtures[street_it].properties['carmen:lparity'] &&
-                                res[res_it].properties['carmen:lfromhn'] === (streetFixtures[street_it].properties['carmen:lfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:lfromhn']) : null) &&
-                                res[res_it].properties['carmen:rparity'] === streetFixtures[street_it].properties['carmen:rparity'] &&
-                                res[res_it].properties['carmen:rfromhn'] === (streetFixtures[street_it].properties['carmen:rfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:rfromhn']) : null) &&
-                                res[res_it].properties['carmen:rtohn']   === (streetFixtures[street_it].properties['carmen:rtohn'] ? parseInt(streetFixtures[street_it].properties['carmen:rtohn']) : null) &&
-                                res[res_it].properties['carmen:ltohn']   === (streetFixtures[street_it].properties['carmen:ltohn'] ? parseInt(streetFixtures[street_it].properties['carmen:ltohn']) : null)
-                            ) resPass = true;
+                            if (res[res_it].properties['carmen:lparity'] !== streetFixtures[street_it].properties['carmen:lparity']) {
+                                t.equals(streetFixtures[street_it].properties['carmen:lparity'], res[res_it].properties['carmen:lparity'], 'lparity matches');
+                            }
+                            if (res[res_it].properties['carmen:lfromhn'] !== (streetFixtures[street_it].properties['carmen:lfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:lfromhn']) : null)) {
+                                t.equals(streetFixtures[street_it].properties['carmen:lfromhn'], res[res_it].properties['carmen:lfromhn'], 'lfromhn matches');
+                            }
+                            if (res[res_it].properties['carmen:rparity'] !== streetFixtures[street_it].properties['carmen:rparity']) {
+                                t.equals(streetFixtures[street_it].properties['carmen:rparity'], res[res_it].properties['carmen:rparity'], 'rparity matches');
+                            }
+                            if (res[res_it].properties['carmen:rfromhn'] !== (streetFixtures[street_it].properties['carmen:rfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:rfromhn']) : null)) {
+                                t.equals(streetFixtures[street_it].properties['carmen:rfromhn'], res[res_it].properties['carmen:rfromhn'], 'rfromhn matches');
+                            }
+                            if (res[res_it].properties['carmen:rtohn'] !== (streetFixtures[street_it].properties['carmen:rtohn'] ? parseInt(streetFixtures[street_it].properties['carmen:rtohn']) : null)) {
+                                t.equals(streetFixtures[street_it].properties['carmen:rtohn'], res[res_it].properties['carmen:rtohn'], 'rtohn matches');
+                            }
+                            if (res[res_it].properties['carmen:ltohn'] !== (streetFixtures[street_it].properties['carmen:ltohn'] ? parseInt(streetFixtures[street_it].properties['carmen:ltohn']) : null)) {
+                                t.equals(streetFixtures[street_it].properties['carmen:ltohn'], res[res_it].properties['carmen:ltohn'], 'ltohn matches');
+                            }
                         }
-
-                        if (!resPass) q.notok('ITP not match any output');
                     }
                     q.end();    
                 });

--- a/test/worker-fixtures.test.js
+++ b/test/worker-fixtures.test.js
@@ -94,25 +94,17 @@ test('worker - fixtures', function(t) {
                         resPass = false;
 
                         for (var res_it = 0; res_it < res.length; res_it++) {
-                            if (res[res_it].properties['carmen:lparity'] !== streetFixtures[street_it].properties['carmen:lparity']) {
-                                t.equals(streetFixtures[street_it].properties['carmen:lparity'], res[res_it].properties['carmen:lparity'], 'lparity matches');
-                            }
-                            if (res[res_it].properties['carmen:lfromhn'] !== (streetFixtures[street_it].properties['carmen:lfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:lfromhn']) : null)) {
-                                t.equals(streetFixtures[street_it].properties['carmen:lfromhn'], res[res_it].properties['carmen:lfromhn'], 'lfromhn matches');
-                            }
-                            if (res[res_it].properties['carmen:rparity'] !== streetFixtures[street_it].properties['carmen:rparity']) {
-                                t.equals(streetFixtures[street_it].properties['carmen:rparity'], res[res_it].properties['carmen:rparity'], 'rparity matches');
-                            }
-                            if (res[res_it].properties['carmen:rfromhn'] !== (streetFixtures[street_it].properties['carmen:rfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:rfromhn']) : null)) {
-                                t.equals(streetFixtures[street_it].properties['carmen:rfromhn'], res[res_it].properties['carmen:rfromhn'], 'rfromhn matches');
-                            }
-                            if (res[res_it].properties['carmen:rtohn'] !== (streetFixtures[street_it].properties['carmen:rtohn'] ? parseInt(streetFixtures[street_it].properties['carmen:rtohn']) : null)) {
-                                t.equals(streetFixtures[street_it].properties['carmen:rtohn'], res[res_it].properties['carmen:rtohn'], 'rtohn matches');
-                            }
-                            if (res[res_it].properties['carmen:ltohn'] !== (streetFixtures[street_it].properties['carmen:ltohn'] ? parseInt(streetFixtures[street_it].properties['carmen:ltohn']) : null)) {
-                                t.equals(streetFixtures[street_it].properties['carmen:ltohn'], res[res_it].properties['carmen:ltohn'], 'ltohn matches');
-                            }
+                            if (
+                                res[res_it].properties['carmen:lparity'] === streetFixtures[street_it].properties['carmen:lparity'] &&
+                                res[res_it].properties['carmen:lfromhn'] === (streetFixtures[street_it].properties['carmen:lfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:lfromhn']) : null) &&
+                                res[res_it].properties['carmen:rparity'] === streetFixtures[street_it].properties['carmen:rparity'] &&
+                                res[res_it].properties['carmen:rfromhn'] === (streetFixtures[street_it].properties['carmen:rfromhn'] ? parseInt(streetFixtures[street_it].properties['carmen:rfromhn']) : null) &&
+                                res[res_it].properties['carmen:rtohn']   === (streetFixtures[street_it].properties['carmen:rtohn'] ? parseInt(streetFixtures[street_it].properties['carmen:rtohn']) : null) &&
+                                res[res_it].properties['carmen:ltohn']   === (streetFixtures[street_it].properties['carmen:ltohn'] ? parseInt(streetFixtures[street_it].properties['carmen:ltohn']) : null)
+                            ) resPass = true;
                         }
+
+                        if (!resPass) q.notok('ITP not match any output');
                     }
                     q.end();    
                 });
@@ -121,3 +113,4 @@ test('worker - fixtures', function(t) {
     });
     t.end();
 });
+


### PR DESCRIPTION
Parity used to be only assigned if the points were 80% the same parity. The lead to ambiguous parity not receiving one. It now assigns automatically for 70% and does a best guess below this.