### PR TITLE
Fix debug behavior

### DIFF
--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -89,7 +89,6 @@ function interpolize(street, address, argv) {
         }
     });
 
-
     //Calculate number of odd/even on each side
     var parity = {
         totall: 0,
@@ -99,12 +98,14 @@ function interpolize(street, address, argv) {
         ro: 0,
         re: 0
     }
+
     dist.forEach(function(d) {
         if (d.side === leftSide && d.number % 2 === 0) parity.le++;
         if (d.side === leftSide && d.number % 2 === 1) parity.lo++;
         if (d.side !== leftSide && d.number % 2 === 0) parity.re++;
         if (d.side !== leftSide && d.number % 2 === 1) parity.ro++;
     });
+
     parity.totall = parity.lo + parity.le;
     parity.totalr = parity.ro + parity.re;
 
@@ -114,6 +115,15 @@ function interpolize(street, address, argv) {
     if (!result.rend && result.rstart) result.rend = result.rstart;
     if (!result.lstart && result.lend) result.lstart = result.lend;
     if (!result.lend && result.lstart) result.lend = result.lstart;
+
+    //Stores the actual matches start/end address - not the one normalized
+    //if the start/end are not both odd or even
+    var actualMatch = {
+        rstart: result.rstart,
+        rend: result.rend,
+        lstart: result.lstart,
+        lend: result.lend
+    }
 
     if (result.rstart && result.rend) {
         if (parity.ro / parity.totalr > 0.70) rparity = 'O';
@@ -131,8 +141,12 @@ function interpolize(street, address, argv) {
         }
 
         if (rparity === 'E') {
-            if (result.rstart % 2 !== 0) result.rstart++;
-            if (result.rend % 2 !== 0) result.rend++;
+            if (result.rstart % 2 !== 0) {
+                result.rstart++;
+            }
+            if (result.rend % 2 !== 0) {
+                result.rend++;
+            }
         } else {
             if (result.rstart % 2 !== 1) result.rstart++;
             if (result.rend % 2 !== 1) result.rend++;
@@ -205,9 +219,9 @@ function interpolize(street, address, argv) {
         'carmen:rangetype': 'tiger'
     }
 
-    if (argv && argv.debug) {
+    if (argv.debug) {
         street.properties.autonamed = autonamed;
-        return debug(address, street)
+        return debug(address, street, actualMatch)
     } else {
         return street;
     }
@@ -239,7 +253,7 @@ function segment(line, dist, units) {
 
 //The debug code also outputs in the format used in test/fixtures which are run by
 // test/worker.test.js
-function debug(address, street) {
+function debug(address, street, actualMatch) {
     var debugFeat = [];
 
     function getPointByAddr(addr) {
@@ -255,25 +269,25 @@ function debug(address, street) {
     }
 
     if (street.properties['carmen:rfromhn']) {
-        debugFeat.push(turf.point(getPointByAddr(street.properties['carmen:rfromhn']), {
+        debugFeat.push(turf.point(getPointByAddr(actualMatch.rstart), {
             'marker-color': '#b80e05',
             'street': street.properties['carmen:text']
         }));
     }
     if (street.properties['carmen:rtohn']) {
-        debugFeat.push(turf.point(getPointByAddr(street.properties['carmen:rtohn']), {
+        debugFeat.push(turf.point(getPointByAddr(actualMatch.rend), {
             'marker-color': '#b80e05',
             'street': street.properties['carmen:text']
         }));
     }
     if (street.properties['carmen:lfromhn']) {
-        debugFeat.push(turf.point(getPointByAddr(street.properties['carmen:lfromhn']), {
+        debugFeat.push(turf.point(getPointByAddr(actualMatch.lstart), {
             'marker-color': '#00a70d',
             'street': street.properties['carmen:text']
         }));
     }
     if (street.properties['carmen:ltohn']) {
-        debugFeat.push(turf.point(getPointByAddr(street.properties['carmen:ltohn']), {
+        debugFeat.push(turf.point(getPointByAddr(actualMatch.lend), {
             'marker-color': '#00a70d',
             'street': street.properties['carmen:text']
         }));


### PR DESCRIPTION
Auto-incrementing the lstart/lend rstart/rend if the parity was not the same had the side affect of breaking debug output.