### PR TITLE
Don't need geojson from tile

### DIFF
--- a/lib/split.js
+++ b/lib/split.js
@@ -30,8 +30,6 @@ module.exports = function(streets, address, street_split, xyz, callback) {
 
     tile.addGeoJSON(JSON.stringify(identicalStreets), 'data');
 
-    var geojson = tile.toGeoJSONSync('data');
-
     address.geometry.coordinates.forEach(function(coord, coord_it) {
         q.defer(function(cb) {
             tile.query(coord[0], coord[1], {


### PR DESCRIPTION
Fixes a fatal error if the tile didn't have GeoJSON.