### PR TITLE
Split require explode

### DIFF
--- a/lib/explode.js
+++ b/lib/explode.js
@@ -22,7 +22,7 @@ function main(streets, settings) {
     if (!settings) settings = {};
 
     let results = {
-        type: 'FeaturesCollection',
+        type: 'FeatureCollection',
         features: []
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,10 +73,11 @@ function copy(pool, stream, type, opts = {}, cb) {
 
         if (!feat || typeof feat !== 'object'|| !feat.properties.street) return;
 
-        if (feat.properties.street === feat.properties.street.toUpperCase()) {
+        if (Array.isArray(feat.properties.street)) feat.properties._text = feat.properties.street.join(',');
+        else feat.properties._text = feat.properties.street;
+
+        if (feat.properties._text === feat.properties._text.toUpperCase()) {
             feat.properties._text = _.startCase(feat.properties.street);
-        } else {
-            feat.properties._text = feat.properties.street
         }
 
         if (feat.properties.street.length > 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,11 @@ function copy(pool, stream, type, opts = {}, cb) {
 
         if (!feat || typeof feat !== 'object'|| !feat.properties.street) return;
 
-        feat.properties._text = _.startCase(feat.properties.street);
+        if (feat.properties.street === feat.properties.street.toUpperCase()) {
+            feat.properties._text = _.startCase(feat.properties.street);
+        } else {
+            feat.properties._text = feat.properties.street
+        }
 
         if (feat.properties.street.length > 0) {
             //@TODO HACK - need to support alt names eventually

--- a/lib/map.js
+++ b/lib/map.js
@@ -116,7 +116,7 @@ module.exports = function(argv, cb) {
 
     //Create Tables, Import, & Optimize by generating indexes
     function createIndex(total) {
-        let bar = new prog('[:bar] :percent :etas Importing Data', {
+        let bar = new prog('ok - Importing Data [:bar] :percent :etas', {
             complete: '=',
             incomplete: ' ',
             width: 20,
@@ -158,7 +158,7 @@ module.exports = function(argv, cb) {
             client.query('SELECT count(*) FROM network WHERE text = \'\';', (err, res) => {
                 if (err) return cb(err);
 
-                let bar = new prog('[:bar] :percent :etas Interpolating Missing Names', {
+                let bar = new prog('ok - Interpolating Missing Names [:bar] :percent :etas', {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,
@@ -249,7 +249,7 @@ module.exports = function(argv, cb) {
             client.query(`SELECT count(*) FROM network_cluster WHERE text != '' AND TEXT IS NOT NULL`, (err, res) => {
                 if (err) return cb(err);
 
-                let bar = new prog('[:bar] :percent :etas Cross Matching Data', {
+                let bar = new prog('ok - Cross Matching Data [:bar] :percent :etas', {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,
@@ -299,7 +299,7 @@ module.exports = function(argv, cb) {
             client.query(`SELECT count(*) FROM network_cluster WHERE text != '' AND address IS NOT NULL;`, (err, res) => {
                 if (err) return cb(err);
 
-                let bar = new prog('[:bar] :percent :etas Splitting Data', {
+                let bar = new prog('ok - Splitting Data [:bar] :percent :etas', {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,
@@ -348,7 +348,7 @@ module.exports = function(argv, cb) {
             client.query(`SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;`, (err, res) => {
                 if (err) return cb(err);
 
-                let bar = new prog('[:bar] :percent :etas Formatting Unmached Addresses', {
+                let bar = new prog('ok - Formatting Unmached Addresses [:bar] :percent :etas', {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,

--- a/lib/map.js
+++ b/lib/map.js
@@ -141,7 +141,7 @@ module.exports = function(argv, cb) {
 
             indexQ.awaitAll((err) => {
                 if (err) throw err;
-                console.error('ok - imported data');
+                console.error('\nok - imported data');
 
                 index.optimize(pool, nameNetwork)
             });

--- a/lib/map.js
+++ b/lib/map.js
@@ -40,9 +40,9 @@ module.exports = function(argv, cb) {
         });
     }
 
-    if (!argv['in-address']) {
+    if (!argv['in-address'] && !argv['skip-import']) {
         return cb(new Error('--in-address=<FILE.geojson> argument required'));
-    } else if (!argv['in-network']) {
+    } else if (!argv['in-network'] && !argv['skip-import']) {
         return cb(new Error('--in-network=<FILE.geojson> argument required'));
     } else if (!argv['output']) {
         return cb(new Error('--output=<FILE.geojson> argument required'));

--- a/lib/split.js
+++ b/lib/split.js
@@ -146,13 +146,6 @@ function split(argv, id, pool, output, cb) {
                     ]
                 }
             }) + '\n');
-
-
-            //Add Network to collection
-            ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
-                ln[prop] = ln[prop].concat(result.properties[prop]);
-            });
-            ln.coords.push(result.geometry.coordinates);
         }
 
         return cb();

--- a/lib/split.js
+++ b/lib/split.js
@@ -215,6 +215,12 @@ function split(argv, id, pool, output, cb) {
             }
         }
 
+        for (potential of itpResults) {
+            if (!potential) continue;
+
+            output.write(JSON.stringify(potential) + '\n');
+        }
+
         return cb();
     });
 }

--- a/lib/split.js
+++ b/lib/split.js
@@ -168,7 +168,7 @@ function split(argv, id, pool, output, cb) {
                 if (!comp || itp_it == compare_it) continue;
 
                 //No addressnumber so add to collection
-                if (!comp.geometry.geometries[1]) {
+                if (!comp.geometry.geometries[1] || !itp.geometry.geometries[1]) {
                     mergeFeat();
                     continue;
                 }

--- a/lib/split.js
+++ b/lib/split.js
@@ -87,7 +87,11 @@ function split(argv, id, pool, output, cb) {
         for (let pt_it = 0; pt_it < cluster.length; pt_it++) {
             //If Network Doesn't have corresponding Address Cluster
             if (!cluster[pt_it]) {
+                feat.network.features[pt_it].geometry.type = 'MultiLineString';
+                feat.network.features[pt_it].geometry.coordinates = [ feat.network.features[pt_it].geometry.coordinates ];
+
                 output.write(JSON.stringify({
+                    id: parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100)),
                     type: 'Feature',
                     properties: {
                         'carmen:text': feat._text,
@@ -123,7 +127,11 @@ function split(argv, id, pool, output, cb) {
 
             result = interpolize(street, address, { zoom: 14 });
 
+            result.geometry.type = 'MultiLineString';
+            result.geometry.coordinates = [ result.geometry.coordinates ];
+
             output.write(JSON.stringify({
+                id: parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100)),
                 type: 'Feature',
                 properties: {
                     'carmen:text': feat._text,

--- a/lib/split.js
+++ b/lib/split.js
@@ -42,7 +42,7 @@ function split(argv, id, pool, output, cb) {
         let network = JSON.parse(res.network);
         let networkFC = [];
         for (let ln_it = 0; ln_it < network.coordinates.length; ln_it++) {
-            networkFC.push(turf.feature(turf.lineString(network.coordinates[ln_it])));
+            networkFC.push(turf.lineString(network.coordinates[ln_it]));
         }
 
         network = explode(turf.featureCollection(networkFC));
@@ -84,50 +84,30 @@ function split(argv, id, pool, output, cb) {
             addressCluster[currentMatch.ln].push(feat.number[pt_it]);
         }
 
-        let collection = {
-            id: parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100)),
-            type: 'Feature',
-            properties: {
-                'carmen:text': feat._text,
-                'carmen:addressnumber': [],
-                'carmen:parityl': [],
-                'carmen:lfromhn': [],
-                'carmen:ltohn':   [],
-                'carmen:parityr': [],
-                'carmen:rfromhn': [],
-                'carmen:rtohn':   [],
-                'carmen:center': false,
-                'carmen:rangetype': 'tiger',
-                'carmen:geocoder_stack': argv.country ? argv.country : false
-            },
-            geometry: {
-                type: 'GeometryCollection',
-                geometries: []
-            }
-        }
-
-        let ln = {
-            'carmen:parityl': [],
-            'carmen:lfromhn': [],
-            'carmen:ltohn':   [],
-            'carmen:parityr': [],
-            'carmen:rfromhn': [],
-            'carmen:rtohn':   [],
-            coords: []
-        }
-
-        let pt = {
-            'carmen:addressnumber': [],
-            coords: []
-        }
-
         for (let pt_it = 0; pt_it < cluster.length; pt_it++) {
             //If Network Doesn't have corresponding Address Cluster
             if (!cluster[pt_it]) {
-                ln.coords.push(feat.network.features[pt_it].geometry);
-                ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
-                    ln[prop].push(null);
-                });
+                output.write(JSON.stringify({
+                    type: 'Feature',
+                    properties: {
+                        'carmen:text': feat._text,
+                        'carmen:addressnumber': [ null ],
+                        'carmen:parityl': [ null ],
+                        'carmen:lfromhn': [ null ],
+                        'carmen:ltohn':   [ null ],
+                        'carmen:parityr': [ null ],
+                        'carmen:rfromhn': [ null ],
+                        'carmen:rtohn':   [ null ],
+                        'carmen:center': turf.pointOnSurface(feat.network.features[pt_it].geometry).geometry.coordinates,
+                        'carmen:rangetype': 'tiger',
+                        'carmen:geocoder_stack': argv.country ? argv.country : false
+                    },
+                    geometry: {
+                        type: 'GeometryCollection',
+                        geometries: [ feat.network.features[pt_it].geometry ]
+                    }
+                }) + '\n');
+
                 continue;
             }
 
@@ -143,9 +123,30 @@ function split(argv, id, pool, output, cb) {
 
             result = interpolize(street, address, { zoom: 14 });
 
-            //Add AddressCluster to collection
-            pt['carmen:addressnumber'] = pt['carmen:addressnumber'].concat(address.properties.numbers);
-            pt.coords = pt.coords.concat(address.geometry.coordinates);
+            output.write(JSON.stringify({
+                type: 'Feature',
+                properties: {
+                    'carmen:text': feat._text,
+                    'carmen:addressnumber': [ null, address.properties.numbers ],
+                    'carmen:parityl': [ result.properties['carmen:parityl'], null ],
+                    'carmen:lfromhn': [ result.properties['carmen:lfromhn'], null ],
+                    'carmen:ltohn':   [ result.properties['carmen:ltohn'], null ],
+                    'carmen:parityr': [ result.properties['carmen:parityr'], null ],
+                    'carmen:rfromhn': [ result.properties['carmen:rfromhn'], null ],
+                    'carmen:rtohn':   [ result.properties['carmen:rtohn'], null ],
+                    'carmen:center': turf.pointOnSurface(feat.network.features[pt_it].geometry).geometry.coordinates,
+                    'carmen:rangetype': 'tiger',
+                    'carmen:geocoder_stack': argv.country ? argv.country : false
+                },
+                geometry: {
+                    type: 'GeometryCollection',
+                    geometries: [
+                        feat.network.features[pt_it].geometry,
+                        { type: 'MultiPoint', coordinates: address.geometry.coordinates }
+                    ]
+                }
+            }) + '\n');
+
 
             //Add Network to collection
             ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
@@ -153,41 +154,6 @@ function split(argv, id, pool, output, cb) {
             });
             ln.coords.push(result.geometry.coordinates);
         }
-
-        if (ln.coords.length) {
-            collection.geometry.geometries.push({
-                type: 'MultiLineString',
-                coordinates: ln.coords
-            });
-            ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
-                collection.properties[prop].push(ln[prop]);
-            });
-
-            collection.properties['carmen:center'] = turf.pointOnSurface({
-                type: 'MultiLineString',
-                coordinates: ln.coords
-            }).geometry.coordinates;
-            collection.properties['carmen:addressnumber'].push(null);
-        }
-
-        if (pt.coords.length) {
-            collection.geometry.geometries.push({
-                type: 'MultiPoint',
-                coordinates: pt.coords
-            });
-            ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
-                collection.properties[prop].push(null);
-            });
-            if (!collection.properties['carmen:center']) {
-                collection.properties['carmen:center'] = turf.pointOnSurface({
-                    type: 'MultiPoint',
-                    coordinates: pt.coords
-                }).geometry.coordinates;
-            }
-            collection.properties['carmen:addressnumber'].push(pt['carmen:addressnumber']);
-        }
-
-        output.write(JSON.stringify(collection) + '\n');
 
         return cb();
     });

--- a/lib/split.js
+++ b/lib/split.js
@@ -1,6 +1,7 @@
 module.exports = split;
 
 const interpolize = require('./interpolize');
+const explode = require('./explode');
 
 const turf = require('@turf/turf');
 

--- a/lib/split.js
+++ b/lib/split.js
@@ -38,13 +38,24 @@ function split(argv, id, pool, output, cb) {
             return addr;
         });
 
+        //Split MultiLineString into individual LineStrings in FeatureCollection
+        let network = JSON.parse(res.network);
+        let networkFC = [];
+        for (let ln_it = 0; ln_it < network.coordinates.length; ln_it++) {
+            networkFC.push(turf.feature(turf.lineString(network.coordinates[ln_it])));
+        }
+
+        network = explode(turf.featureCollection(networkFC));
+
         let feat = {
             text: res.text,
             _text: res._text,
             number: res.number,
-            network: JSON.parse(res.network),
+            network: network,
             address: res.address
         }
+
+        feat.network = explode(feat.network);
 
         let cluster = [];
         let addressCluster = [];
@@ -57,8 +68,8 @@ function split(argv, id, pool, output, cb) {
                 ln: false
             };
 
-            for (let ln_it = 0; ln_it < feat.network.coordinates.length; ln_it++) {
-                let ln = turf.lineString(feat.network.coordinates[ln_it]);
+            for (let ln_it = 0; ln_it < feat.network.features.length; ln_it++) {
+                let ln = feat.network.features[ln_it].geometry;
 
                 let dist = turf.distance(turf.pointOnLine(ln, pt), pt);
 
@@ -113,7 +124,7 @@ function split(argv, id, pool, output, cb) {
         for (let pt_it = 0; pt_it < cluster.length; pt_it++) {
             //If Network Doesn't have corresponding Address Cluster
             if (!cluster[pt_it]) {
-                ln.coords.push(feat.network.coordinates[pt_it]);
+                ln.coords.push(feat.network.features[pt_it].geometry);
                 ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
                     ln[prop].push(null);
                 });
@@ -125,7 +136,7 @@ function split(argv, id, pool, output, cb) {
                 text: feat.text,
                 'carmen:text': feat._text
             });
-            let street = turf.lineString(feat.network.coordinates[pt_it], {
+            let street = turf.feature(feat.network.features[pt_it].geometry, {
                 text: feat.text,
                 'carmen:text': feat._text
             });

--- a/lib/split.js
+++ b/lib/split.js
@@ -84,13 +84,12 @@ function split(argv, id, pool, output, cb) {
             addressCluster[currentMatch.ln].push(feat.number[pt_it]);
         }
 
+        let itpResults = [];
+
         for (let pt_it = 0; pt_it < cluster.length; pt_it++) {
             //If Network Doesn't have corresponding Address Cluster
             if (!cluster[pt_it]) {
-                feat.network.features[pt_it].geometry.type = 'MultiLineString';
-                feat.network.features[pt_it].geometry.coordinates = [ feat.network.features[pt_it].geometry.coordinates ];
-
-                output.write(JSON.stringify({
+                itpResults.push({
                     id: parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100)),
                     type: 'Feature',
                     properties: {
@@ -110,7 +109,7 @@ function split(argv, id, pool, output, cb) {
                         type: 'GeometryCollection',
                         geometries: [ feat.network.features[pt_it].geometry ]
                     }
-                }) + '\n');
+                });
 
                 continue;
             }
@@ -127,10 +126,7 @@ function split(argv, id, pool, output, cb) {
 
             result = interpolize(street, address, { zoom: 14 });
 
-            result.geometry.type = 'MultiLineString';
-            result.geometry.coordinates = [ result.geometry.coordinates ];
-
-            output.write(JSON.stringify({
+            itpResults.push({
                 id: parseInt(new Date() / 1 + '' + Math.floor(Math.random() * 100)),
                 type: 'Feature',
                 properties: {
@@ -153,7 +149,20 @@ function split(argv, id, pool, output, cb) {
                         { type: 'MultiPoint', coordinates: address.geometry.coordinates }
                     ]
                 }
-            }) + '\n');
+            });
+        }
+
+        let current = false;
+        //Iterate through each result and check for duplicate address pts
+        for (let itp_it = 0; itp_it < itpResults.length; itp_it++) {
+            let itp = itpResults[itp_it];
+            if (!itp) continue;
+
+            for (let compare_it = 0; compare_it < itpResults.length; compare_it++) {
+                let comp = itpResults[compare_it];
+                if (!comp) continue;
+
+            }
         }
 
         return cb();

--- a/lib/split.js
+++ b/lib/split.js
@@ -152,16 +152,62 @@ function split(argv, id, pool, output, cb) {
             });
         }
 
-        let current = false;
         //Iterate through each result and check for duplicate address pts
         for (let itp_it = 0; itp_it < itpResults.length; itp_it++) {
             let itp = itpResults[itp_it];
+
+            itp.geometry.geometries[0] = {
+                type: 'MultiLineString',
+                coordinates: [ itp.geometry.geometries[0] ]
+            }
+
             if (!itp) continue;
 
             for (let compare_it = 0; compare_it < itpResults.length; compare_it++) {
                 let comp = itpResults[compare_it];
-                if (!comp) continue;
+                if (!comp || itp_it == compare_it) continue;
 
+                //No addressnumber so add to collection
+                if (!comp.geometry.geometries[1]) {
+                    mergeFeat();
+                    continue;
+                }
+
+                //Iterate through each AddressNumber and ensure there aren't dups
+                let dup = false;
+                for (addr of comp.properties['carmen:addressnumber']) {
+                    if (itp.properties['carmen:addressnumber'][1].indexOf(addr) !== -1) {
+                        dup = true;
+                        break;
+                    }
+                }
+
+                if (!dup) {
+                    mergeFeat();
+                    continue;
+                }
+
+
+                function mergeFeat() {
+                    itp.geometry.geometries[0].coordinates.push(comp.geometry.geometries[0].coordinates);
+                    ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
+                        itp.properties[prop][0].push(comp.properties[prop][0]);
+                    });
+                    itpResults[comp_it] = false;
+
+                    if (comp.geometry.geometries[1]) {
+                        if (!itp.geometry.geometries[1]) {
+                            itp.geometry.geometries[1] = {
+                                type: 'MultiPoints',
+                                coordinates: []
+                            }
+                        }
+
+                        itp.properties['carmen:addressnumber'][1] = itp.properties['carmen:addressnumber'][1].concat(comp.properties['carmen:addressnumber'][1]);
+
+                        itp.geometry.geometries[1].coordinates = itp.geometry.geometries[1].coordinates.concat(comp.geometry.geometries[1].coordinates);
+                    }
+                }
             }
         }
 

--- a/lib/split.js
+++ b/lib/split.js
@@ -159,7 +159,7 @@ function split(argv, id, pool, output, cb) {
 
             itp.geometry.geometries[0] = {
                 type: 'MultiLineString',
-                coordinates: [ itp.geometry.geometries[0] ]
+                coordinates: [ itp.geometry.geometries[0].coordinates ]
             };
             ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
                 itp.properties[prop][0] = [ itp.properties[prop][0] ];

--- a/lib/split.js
+++ b/lib/split.js
@@ -155,13 +155,15 @@ function split(argv, id, pool, output, cb) {
         //Iterate through each result and check for duplicate address pts
         for (let itp_it = 0; itp_it < itpResults.length; itp_it++) {
             let itp = itpResults[itp_it];
+            if (!itp) continue;
 
             itp.geometry.geometries[0] = {
                 type: 'MultiLineString',
                 coordinates: [ itp.geometry.geometries[0] ]
-            }
-
-            if (!itp) continue;
+            };
+            ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
+                itp.properties[prop][0] = [ itp.properties[prop][0] ];
+            });
 
             for (let compare_it = 0; compare_it < itpResults.length; compare_it++) {
                 let comp = itpResults[compare_it];
@@ -193,20 +195,22 @@ function split(argv, id, pool, output, cb) {
                     ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
                         itp.properties[prop][0].push(comp.properties[prop][0]);
                     });
-                    itpResults[comp_it] = false;
 
                     if (comp.geometry.geometries[1]) {
                         if (!itp.geometry.geometries[1]) {
                             itp.geometry.geometries[1] = {
-                                type: 'MultiPoints',
+                                type: 'MultiPoint',
                                 coordinates: []
                             }
+                            
+                            itp.properties['carmen:addressnumber'][1] = [];
                         }
 
                         itp.properties['carmen:addressnumber'][1] = itp.properties['carmen:addressnumber'][1].concat(comp.properties['carmen:addressnumber'][1]);
 
                         itp.geometry.geometries[1].coordinates = itp.geometry.geometries[1].coordinates.concat(comp.geometry.geometries[1].coordinates);
                     }
+                    itpResults[compare_it] = false;
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,8 @@
   },
   "eslintConfig": {
     "rules": {
-      "no-use-before-define": [
-        2,
-        "nofunc"
-      ],
-      "space-before-function-paren": [
-        2,
-        "never"
-      ],
+      "no-use-before-define": [ 2, "nofunc" ],
+      "space-before-function-paren": [ 2, "never" ],
       "space-in-parens": 2,
       "space-before-blocks": 2,
       "keyword-spacing": 2,


### PR DESCRIPTION
Ref: https://github.com/ingalls/pt2itp/issues/59

Luxembourg Addresses Show that I need to bring back the explode module.

<img width="584" alt="bad match" src="https://cloud.githubusercontent.com/assets/1297009/25486507/6e0c8c9c-2b2f-11e7-8d2d-4c078d1257e6.png">

Streets should be grouped based on continuity and sliced based on this continuity instead of grouped into the current ST_Cluster