### PR TITLE
Add diacritic handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,9 +89,11 @@ class Index {
         let unit_it = 0;
         let reverseMap = new Map();
 
+        let psv = `${os.tmpDir()}/${type}-${(new Date).getTime()}.psv`
+
         let rl = readline.createInterface({
             input: stream,
-            output: fs.createWriteStream(`${os.tmpDir()}/${type}.psv`)
+            output: fs.createWriteStream(psv)
         });
 
         rl.on('line', (line) => {
@@ -179,8 +181,8 @@ class Index {
                 if (err) return cb(err);
 
                 let query;
-                if (type === 'address') query = `COPY address (text, _text, lon, lat, number) FROM '${os.tmpDir()}/address.psv' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
-                else query = `COPY network (text, _text, geomtext) FROM '${os.tmpDir()}/network.psv' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
+                if (type === 'address') query = `COPY address (text, _text, lon, lat, number) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
+                else query = `COPY network (text, _text, geomtext) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
 
                 client.query(String(query), (err, res) => {
                     cb(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const os = require('os');
 const fs = require('fs');
 const readline = require('readline');
 const title = require('to-title-case');
+const diacritics('diacritics').remove;
 
 const tokenize = require('./tokenize');
 
@@ -138,7 +139,7 @@ class Index {
 
             feat.properties._text = title(feat.properties.street);                                  //The _text value is what is displayed to the user - it should not be modified after this
 
-            feat.properties.street = tokenize(feat.properties.street, opts.tokens).join(' ');       //The street is standardized and it what is used to compare to the address cluster
+            feat.properties.street = diacritics(tokenize(feat.properties.street, opts.tokens).join(' '));       //The street is standardized and it what is used to compare to the address cluster
 
             if (type === 'address') {
                 if (feat.properties.number === null) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const os = require('os');
 const fs = require('fs');
 const readline = require('readline');
 const title = require('to-title-case');
-const diacritics('diacritics').remove;
+const diacritics = require('diacritics').remove;
 
 const tokenize = require('./tokenize');
 

--- a/lib/split.js
+++ b/lib/split.js
@@ -2,6 +2,7 @@ module.exports = split;
 
 const interpolize = require('./interpolize');
 const explode = require('./explode');
+const diacritics = require('diacritics').remove;
 
 const turf = require('@turf/turf');
 
@@ -41,8 +42,8 @@ function split(argv, id, pool, output, cb) {
 
         let network = JSON.parse(res.network);
 
-        let text = res.n_text;
-        if (text !== res.a_next) text = text + ',' + res.a_text;
+        let text = res.a_text;
+        if (diacritics(text) !== diacritics(res.n_next)) text = text + ',' + res.n_text;
 
         let feat = {
             text: res.ntext,

--- a/lib/split.js
+++ b/lib/split.js
@@ -8,8 +8,9 @@ const turf = require('@turf/turf');
 function split(argv, id, pool, output, cb) {
     pool.query(`
         SELECT
-            network_cluster.text                AS text,
-            network_cluster._text               AS _text,
+            network_cluster.text                AS ntext,
+            network_cluster._text               AS n_text,
+            address_cluster._text               AS a_text,
             ST_AsGeoJSON(network_cluster.geom)  AS network,
             ST_AsGeoJSON(address_cluster.geom)  AS address
         FROM
@@ -40,9 +41,12 @@ function split(argv, id, pool, output, cb) {
 
         let network = JSON.parse(res.network);
 
+        let text = res.n_text;
+        if (text !== res.a_next) text = text + ',' + res.a_next;
+
         let feat = {
-            text: res.text,
-            _text: res._text,
+            text: res.ntext,
+            _text: text,
             number: res.number,
             network: network,
             address: res.address

--- a/lib/split.js
+++ b/lib/split.js
@@ -43,7 +43,7 @@ function split(argv, id, pool, output, cb) {
         let network = JSON.parse(res.network);
 
         let text = res.a_text;
-        if (diacritics(text) !== diacritics(res.n_next)) text = text + ',' + res.n_text;
+        if (diacritics(text) !== diacritics(res.n_text)) text = text + ',' + res.n_text;
 
         let feat = {
             text: res.ntext,

--- a/lib/split.js
+++ b/lib/split.js
@@ -42,7 +42,7 @@ function split(argv, id, pool, output, cb) {
         let network = JSON.parse(res.network);
 
         let text = res.n_text;
-        if (text !== res.a_next) text = text + ',' + res.a_next;
+        if (text !== res.a_next) text = text + ',' + res.a_text;
 
         let feat = {
             text: res.ntext,

--- a/lib/test.js
+++ b/lib/test.js
@@ -135,14 +135,20 @@ function test(argv, cb) {
                                         let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
                                         let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
 
-                                        let dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
+                                        let dist = false;
+                                        if (res.features[0].geometry.type === 'Point') {
+                                            dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
+                                        }
 
                                         if (matched !== cleanQuery) {
                                             stats.fail++;
                                             return done(null, `TEXT FAIL => ${res.features[0].place_name}|${query}|${opts.proximity.join(',')}`);
-                                        } else if (dist > 1) {
+                                        } else if (dist && dist > 1) {
                                             stats.fail++;
-                                            return done(null, `DIST FAIL - ${dist}km - returned: ${res.features[0].geometry.coordinates}  |${query}|${opts.proximity.join(',')}`);
+                                            return done(null, `DIST FAIL - ${dist.toFixed(2)}km - returned: ${res.features[0].geometry.coordinates}|${query}|${opts.proximity.join(',')}`);
+                                        } else if (!dist) { //Usually a street level result
+                                            stats.fail++;
+                                            return done(null, `DIST FAIL|${query}|${opts.proximity.join(',')}`);
                                         }
 
                                         return done(null, true);

--- a/lib/test.js
+++ b/lib/test.js
@@ -85,96 +85,100 @@ function test(argv, cb) {
         index.getMeta(true, (err, meta) => {
             if (err) return cb(err);
 
-            client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;', (err, res) => {
-                if (err) return cb(err);
+            matched();
 
-                const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;'));
+            function matched() {
+                client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;', (err, res) => {
+                    if (err) return cb(err);
 
-                const bar = new prog('ok - Testing Network Matched Addresses [:bar] :percent :etas', {
-                    complete: '=',
-                    incomplete: ' ',
-                    width: 20,
-                    total: res.rows[0].count++
-                });
-                bar.tick(1);
+                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;'));
 
-                return iterate();
+                    const bar = new prog('ok - Testing Network Matched Addresses [:bar] :percent :etas', {
+                        complete: '=',
+                        incomplete: ' ',
+                        width: 20,
+                        total: res.rows[0].count++
+                    });
+                    bar.tick(1);
 
-                function iterate() {
-                    cursor.read(cursor_it, (err, rows) => {
-                        if (err) return cb(err);
+                    return iterate();
 
-                        if (!rows.length) {
-                            return unmatched();
-                        }
-
-                        let addrQ = Queue(25);
-
-                        for (let row of rows) {
-                            row.geom = JSON.parse(row.geom);
-
-                            for (let addr of row.geom.coordinates) {
-                                if (addr[2] % 1 != 0 && meta.units) {
-                                    let unit = parseInt(String(addr[2]).split('.')[1]);
-                                    let num = String(addr[2]).split('.')[0];
-
-                                    addr[2] = `${num}${meta.units[unit]}`;
-                                }
-
-                                addrQ.defer((query, opts, done) => {
-                                    stats.total++;
-                                    c.geocode(query, opts, (err, res) => {
-                                        if (err) return done(err.toString());
-
-                                        if (!res.features.length) {
-                                            stats.fail++;
-                                            return done(null, `NO RESULTS|${query}|${opts.proximity.join(',')}`);
-                                        }
-
-                                        let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
-                                        let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
-
-                                        let dist = false;
-                                        if (res.features[0].geometry.type === 'Point') {
-                                            dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
-                                        }
-
-                                        if (matched !== cleanQuery) {
-                                            stats.fail++;
-                                            return done(null, `TEXT FAIL => ${res.features[0].place_name}|${query}|${opts.proximity.join(',')}`);
-                                        } else if (dist && dist > 1) {
-                                            stats.fail++;
-                                            return done(null, `DIST FAIL - ${dist.toFixed(2)}km - returned: ${res.features[0].geometry.coordinates}|${query}|${opts.proximity.join(',')}`);
-                                        } else if (!dist) { //Usually a street level result
-                                            stats.fail++;
-                                            return done(null, `DIST FAIL|${query}|${opts.proximity.join(',')}`);
-                                        }
-
-                                        return done(null, true);
-
-                                    });
-                                }, `${addr[2]} ${row._text}`, {
-                                    proximity: [ addr[0], addr[1] ]
-                                });
-                            }
-                        }
-
-                        addrQ.awaitAll((err, res) => {
+                    function iterate() {
+                        cursor.read(cursor_it, (err, rows) => {
                             if (err) return cb(err);
 
-                            for (let r of res) {
-                                if (r === true) continue;
-
-                                errOut.write(`${r}\n`);
+                            if (!rows.length) {
+                                return unmatched();
                             }
 
-                            bar.tick(cursor_it);
-                            return iterate();
-                        });
-                    });
-                } 
+                            let addrQ = Queue(25);
 
-            });
+                            for (let row of rows) {
+                                row.geom = JSON.parse(row.geom);
+
+                                for (let addr of row.geom.coordinates) {
+                                    if (addr[2] % 1 != 0 && meta.units) {
+                                        let unit = parseInt(String(addr[2]).split('.')[1]);
+                                        let num = String(addr[2]).split('.')[0];
+
+                                        addr[2] = `${num}${meta.units[unit]}`;
+                                    }
+
+                                    addrQ.defer((query, opts, done) => {
+                                        stats.total++;
+                                        c.geocode(query, opts, (err, res) => {
+                                            if (err) return done(err.toString());
+
+                                            if (!res.features.length) {
+                                                stats.fail++;
+                                                return done(null, `NO RESULTS|${query}|${opts.proximity.join(',')}`);
+                                            }
+
+                                            let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
+                                            let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
+
+                                            let dist = false;
+                                            if (res.features[0].geometry.type === 'Point') {
+                                                dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
+                                            }
+
+                                            if (matched !== cleanQuery) {
+                                                stats.fail++;
+                                                return done(null, `TEXT FAIL => ${res.features[0].place_name}|${query}|${opts.proximity.join(',')}`);
+                                            } else if (dist && dist > 1) {
+                                                stats.fail++;
+                                                return done(null, `DIST FAIL - ${dist.toFixed(2)}km - returned: ${res.features[0].geometry.coordinates}|${query}|${opts.proximity.join(',')}`);
+                                            } else if (!dist) { //Usually a street level result
+                                                stats.fail++;
+                                                return done(null, `DIST FAIL|${query}|${opts.proximity.join(',')}`);
+                                            }
+
+                                            return done(null, true);
+
+                                        });
+                                    }, `${addr[2]} ${row._text}`, {
+                                        proximity: [ addr[0], addr[1] ]
+                                    });
+                                }
+                            }
+
+                            addrQ.awaitAll((err, res) => {
+                                if (err) return cb(err);
+
+                                for (let r of res) {
+                                    if (r === true) continue;
+
+                                    errOut.write(`${r}\n`);
+                                }
+
+                                bar.tick(cursor_it);
+                                setImmediate(iterate);
+                            });
+                        });
+                    } 
+
+                });
+            }
 
             function unmatched() {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
@@ -218,7 +222,7 @@ function test(argv, cb) {
                             }
 
                             bar.tick(cursor_it);
-                            return iterate();
+                            timer.setImmediate(iterate);
                         });
                     } 
 
@@ -269,7 +273,7 @@ function test(argv, cb) {
                             }
 
                             bar.tick(cursor_it);
-                            return iterate();
+                            timer.setImmediate(iterate);
                         });
                     } 
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -135,12 +135,14 @@ function test(argv, cb) {
                                         let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
                                         let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
 
+                                        let dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
+
                                         if (matched !== cleanQuery) {
                                             stats.fail++;
                                             return done(null, `TEXT FAIL => ${res.features[0].place_name}|${query}|${opts.proximity.join(',')}`);
-                                        } else if (turf.distance(res.features[0], opts.proximity, 'kilometers') > 1) {
+                                        } else if (dist > 1) {
                                             stats.fail++;
-                                            return done(null, `DIST FAIL|${query}|${opts.proximity.join(',')}`);
+                                            return done(null, `DIST FAIL - ${dist}km - returned: ${res.features[0].geometry.coordinates}  |${query}|${opts.proximity.join(',')}`);
                                         }
 
                                         return done(null, true);

--- a/lib/test.js
+++ b/lib/test.js
@@ -105,8 +105,7 @@ function test(argv, cb) {
                         if (err) return cb(err);
 
                         if (!rows.length) {
-                            pg_done();
-                            return complete();
+                            return unmatched();
                         }
 
                         let addrQ = Queue(25);
@@ -177,13 +176,62 @@ function test(argv, cb) {
 
             });
 
-            function complete() {
+            function unmatched() {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
                     if (err) return cb(err);
 
                     const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;'));
 
                     const bar = new prog('ok - Unmatched Addresses [:bar] :percent :etas', {
+                        complete: '=',
+                        incomplete: ' ',
+                        width: 20,
+                        total: res.rows[0].count++
+                    });
+                    bar.tick(1);
+
+                    return iterate();
+
+                    function iterate() {
+                        cursor.read(cursor_it, (err, rows) => {
+                            if (err) return cb(err);
+
+                            if (!rows.length) {
+                                diffName();
+                            }
+
+                            for (let row of rows) {
+                                row.geom = JSON.parse(row.geom);
+
+                                for (let addr of row.geom.coordinates) {
+                                    if (addr[2] % 1 != 0 && meta.units) {
+                                        let unit = parseInt(String(addr[2]).split('.')[1]);
+                                        let num = String(addr[2]).split('.')[0];
+
+                                        addr[2] = `${num}${meta.units[unit]}`;
+                                    }
+
+                                    stats.total++;
+                                    stats.fail++;
+                                    errOut.write(`NOT MATCHED TO NETWORK|${addr[2]} ${row._text}|${addr[0]},${addr[1]}\n`);
+                                }
+                            }
+
+                            bar.tick(cursor_it);
+                            return iterate();
+                        });
+                    } 
+
+                });
+            }
+
+            function diffName() {
+                client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text;', (err, res) => {
+                    if (err) return cb(err);
+
+                    const cursor = client.query(new Cursor('SELECT a._text AS atext, n._text AS ntext, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text;'));
+
+                    const bar = new prog('ok - Name Mismatch [:bar] :percent :etas', {
                         complete: '=',
                         incomplete: ' ',
                         width: 20,
@@ -216,7 +264,7 @@ function test(argv, cb) {
 
                                     stats.total++;
                                     stats.fail++;
-                                    errOut.write(`NOT MATCHED TO NETWORK|${addr[2]} ${row._text}|${addr[0]},${addr[1]}\n`);
+                                    errOut.write(`NAME MISMATCH: Network: ${row.ntext} vs: |${addr[2]} ${row.atext}|${addr[0]},${addr[1]}\n`);
                                 }
                             }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -9,6 +9,7 @@ const Cursor = require('pg-cursor');
 const Carmen = require('@mapbox/carmen');
 const MBTiles = require('@mapbox/mbtiles');
 const Queue = require('d3-queue').queue;
+const diacritics = require('diacritics').remove;
 
 const Index = require('./index');
 const tokenize = require('./tokenize');
@@ -131,8 +132,8 @@ function test(argv, cb) {
                                             return done(null, `NO RESULTS|${query}|${opts.proximity.join(',')}`);
                                         }
 
-                                        let matched = tokenize(res.features[0].place_name, meta.tokens).join(' ');
-                                        let cleanQuery = tokenize(query, meta.tokens).join(' ');
+                                        let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
+                                        let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
 
                                         if (matched !== cleanQuery) {
                                             stats.fail++;

--- a/lib/test.js
+++ b/lib/test.js
@@ -88,6 +88,7 @@ function test(argv, cb) {
             matched();
 
             function matched() {
+                console.error('ok - beginning match');
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;', (err, res) => {
                     if (err) return cb(err);
 
@@ -181,6 +182,7 @@ function test(argv, cb) {
             }
 
             function unmatched() {
+                console.error('ok - beginning unmatch');
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
                     if (err) return cb(err);
 
@@ -201,7 +203,7 @@ function test(argv, cb) {
                             if (err) return cb(err);
 
                             if (!rows.length) {
-                                diffName();
+                                return diffName();
                             }
 
                             for (let row of rows) {
@@ -222,7 +224,7 @@ function test(argv, cb) {
                             }
 
                             bar.tick(cursor_it);
-                            timer.setImmediate(iterate);
+                            setImmediate(iterate);
                         });
                     } 
 
@@ -230,6 +232,7 @@ function test(argv, cb) {
             }
 
             function diffName() {
+                console.error('ok - beginning diff name');
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text;', (err, res) => {
                     if (err) return cb(err);
 
@@ -252,7 +255,7 @@ function test(argv, cb) {
                             if (!rows.length) {
                                 pg_done();
                                 console.error(`ok - ${stats.fail}/${stats.total} failed to geocode`);
-                                return;
+                                return cb();
                             }
 
                             for (let row of rows) {
@@ -273,7 +276,7 @@ function test(argv, cb) {
                             }
 
                             bar.tick(cursor_it);
-                            timer.setImmediate(iterate);
+                            setImmediate(iterate);
                         });
                     } 
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mapbox/tilebelt": "^1.0.1",
     "@turf/turf": "^4.2.0",
     "d3-queue": "^3.0.7",
+    "diacritics": "^1.3.0",
     "express": "^4.15.2",
     "fast-levenshtein": "^2.0.6",
     "lodash": "^4.2.0",


### PR DESCRIPTION
- :tada: Add diacritic handling to both the test mode & std. `street` field
- rocket: Use `address._text` as definitive name and add `network._text` as syn when they differ
- :bug: Make `psv` files in `lib/copy` have unique names so pt2itp can run in parallel
- :rocket: `test` mode now outputs when network and address text differ as an error