### PR TITLE
Precision

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const os = require('os');
 const fs = require('fs');
+const turf = require('@turf/turf');
 const readline = require('readline');
 const title = require('to-title-case');
 const diacritics = require('diacritics').remove;
@@ -120,6 +121,8 @@ class Index {
                 }
                 return;
             }
+
+            feat = turf.truncate(feat, 6, 2, true);
 
             if (!feat.properties.street) {
                 if (opts.error) {
@@ -255,7 +258,7 @@ class Index {
         //Set number as 3D coord to track through :') tears of painful happiness
         this.pool.query(`
             BEGIN;
-            UPDATE address SET geom = ST_SetSRID(ST_MakePoint(lon::NUMERIC, lat::NUMERIC, number), 4326);
+            UPDATE address SET geom = ST_SetSRID(ST_MakePoint(substring(lon from 1 for 10)::NUMERIC, substring(lat from 1 for 10)::NUMERIC, number), 4326);
             UPDATE network SET geom = ST_SetSRID(ST_GeomFromGeoJSON(geomtext), 4326);
 
             CREATE INDEX network_idx ON network (text);

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,8 @@ class Index {
 
             feat = turf.truncate(feat, 6, 2, true);
 
-            if (!feat.properties.street) {
+            //Streets will attempt to be named if they are missing later on
+            if (type === 'address' && !feat.properties.street) {
                 if (opts.error) {
                     opts.error.write(`Missing street name\t${line}\n`);
                 }

--- a/lib/map/minjur.js
+++ b/lib/map/minjur.js
@@ -49,10 +49,9 @@ module.exports.map = function(feat) {
     if (!names.length) names = '';
     else if (names.length === 1) names = names[0]; //String for 1 value array for many
 
-    if (['track', 'service'].indexOf(feat.properties.highway) && !feat.properties.street.trim().length) {
+    if (['track', 'service'].indexOf(feat.properties.highway) && !names.length) {
         return false; //Track and service roads should only be allowed if they are already named
     }
-
 
     return {
         type: 'Feature',

--- a/lib/map/minjur.js
+++ b/lib/map/minjur.js
@@ -49,6 +49,11 @@ module.exports.map = function(feat) {
     if (!names.length) names = '';
     else if (names.length === 1) names = names[0]; //String for 1 value array for many
 
+    if (['track', 'service'].indexOf(feat.properties.highway) && !feat.properties.street.trim().length) {
+        return false; //Track and service roads should only be allowed if they are already named
+    }
+
+
     return {
         type: 'Feature',
         properties: {

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -11,8 +11,10 @@ module.exports.map = map;
 function map(feat) {
     //Skip points & Polygons
     if (feat.geometry.type !== 'Point') return new Error('Feat must be a Point geom');
-    if (!feat.properties || !feat.properties.number) return new Error('Feat must have number property');
-    if (!feat.properties || !feat.properties.street) return new Error('Feat must have street property');
+    if (!feat.properties) return new Error('Feat must have properties object');
+    if (!feat.properties.number) return new Error('Feat must have number property');
+    if (!feat.properties.street) return new Error('Feat must have street property');
+    if (!feat.properties.street.trim().length) return new Error('Feat must have non-empty street property');
 
     if (!feat.geometry.coordinates instanceof Array || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
 

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -36,7 +36,7 @@ function map(feat) {
 
     if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat is not a supported address/unit type');
 
-    if (feat.properties.number > 10) return new Error('Number should not exceed 10 chars');
+    if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 
     return feat;
 }

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -34,5 +34,7 @@ function map(feat) {
 
     if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat is not a supported address/unit type');
 
+    if (feat.properties.number > 10) return new Error('Number should not exceed 10 chars');
+
     return feat;
 }

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -17,7 +17,7 @@ function map(feat) {
     if (!feat.geometry.coordinates instanceof Array || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
 
     if (isNaN(feat.geometry.coordinates[0]) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
-    if (isNaN(feat.geometry.coordinates[1]) || feat.geometry.coordinates[1] < -90  || feat.geometry.coordinates[1] > 90) return new Error('Feat exceeds +/-90deg coord bounds');
+    if (isNaN(feat.geometry.coordinates[1]) || feat.geometry.coordinates[1] < -85  || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');
 
     if (!feat.geometry.coordinates instanceof Array || feat.geometry.coordinates.length !== 2) {
         return false;


### PR DESCRIPTION
- :rocket: Limit precision of coordinates to avoid `NUMERIC` overflows
- :rocket: `number` (civic address) are only allowed to be 10 chars long to reduce bad data - can bump in the future if needed
- :rocket: Unnamed large streets are allowed