### PR TITLE
[wip] individual geocoding script, bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 ## Version History
 
+### unreleased / proposed merge
+
+- :rocket: adds a `lib/geocode.js` that takes `lib/test.js`-like set of parameters to geocode a single query
+- :rocket: modularizes geocoding capability too
+- :tada: adds `--limit` param to `test.js`
+- :rocket: weight linker comparisons to deemphasize mismatches based purely on tokens
+    - adds `text_tokenless` column to `address_cluster` & `network_cluster` tables
+    - handle all-token special case by checking for substring status
+- :rocket: detection of candidate address_clusters now uses `ST_Intersects` instead of `ST_Contains`
+- :bug: fix JS error in web interface related to features w/o itp data
+
 ### v9.23.1
 
 - :bug: Using global tokens would break `test` mode

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -23,13 +23,13 @@ class Cluster {
             CREATE TABLE address_cluster AS SELECT
                 addr.text,
                 addr._text,
-		addr.text_tokenless,
+                addr.text_tokenless,
                 ST_Multi(ST_CollectionExtract(addr.geom, 1)) AS geom
             FROM (
                 SELECT
                     text,
                     MAX(_text) AS _text,
-		    MAX(text_tokenless) AS text_tokenless,
+                    MAX(text_tokenless) AS text_tokenless,
                     unnest(ST_ClusterWithin(geom, 0.01)) AS geom
                 FROM address
                 GROUP BY text
@@ -59,13 +59,13 @@ class Cluster {
             CREATE TABLE network_cluster AS SELECT
                 netw.text,
                 netw._text,
-		netw.text_tokenless,
+                netw.text_tokenless,
                 ST_Multi(ST_CollectionExtract(netw.geom, 2)) AS geom
             FROM (
                 SELECT
                     text,
                     MAX(_text) AS _text,
-		    MAX(text_tokenless) AS text_tokenless,
+                    MAX(text_tokenless) AS text_tokenless,
                     unnest(ST_ClusterWithin(geom, 0.01)) AS geom
                 FROM network
                 GROUP BY text

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -23,11 +23,13 @@ class Cluster {
             CREATE TABLE address_cluster AS SELECT
                 addr.text,
                 addr._text,
+		addr.text_tokenless,
                 ST_Multi(ST_CollectionExtract(addr.geom, 1)) AS geom
             FROM (
                 SELECT
                     text,
                     MAX(_text) AS _text,
+		    MAX(text_tokenless) AS text_tokenless,
                     unnest(ST_ClusterWithin(geom, 0.01)) AS geom
                 FROM address
                 GROUP BY text
@@ -57,11 +59,13 @@ class Cluster {
             CREATE TABLE network_cluster AS SELECT
                 netw.text,
                 netw._text,
+		netw.text_tokenless,
                 ST_Multi(ST_CollectionExtract(netw.geom, 2)) AS geom
             FROM (
                 SELECT
                     text,
                     MAX(_text) AS _text,
+		    MAX(text_tokenless) AS text_tokenless,
                     unnest(ST_ClusterWithin(geom, 0.01)) AS geom
                 FROM network
                 GROUP BY text
@@ -102,8 +106,10 @@ class Cluster {
         this.pool.query(`
             SELECT
                 network.text AS network,
+                network.text_tokenless AS network_text_tokenless,
                 addr.id,
-                addr.text
+                addr.text,
+                addr.text_tokenless AS text_tokenless
             FROM
                 address_cluster addr,
                 network_cluster AS network
@@ -117,7 +123,8 @@ class Cluster {
 
             let address = linker({
                 id: id,
-                text: res.rows[0].network
+                text: res.rows[0].network,
+                text_tokenless: res.rows[0].network_text_tokenless
             }, res.rows)
 
             if (!address) return cb();

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -109,7 +109,7 @@ class Cluster {
                 network_cluster AS network
             WHERE
                 network.id = ${id} AND
-                ST_Contains(network.buffer, addr.geom);
+                ST_Intersects(network.buffer, addr.geom);
         `, (err, res) => {
             if (err) return cb(err);
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -149,12 +149,13 @@ class Cluster {
 
             let names = {};
 
-            this.pool.query(`SELECT text, _text FROM address WHERE ST_Within(geom, ST_SetSRID(ST_GeomFromGeoJSON('${JSON.stringify(buff)}'), 4326))`, (err, res) => {
+            this.pool.query(`SELECT text, text_tokenless, _text FROM address WHERE ST_Within(geom, ST_SetSRID(ST_GeomFromGeoJSON('${JSON.stringify(buff)}'), 4326))`, (err, res) => {
                 if (err) return cb(err);
 
                 for (let res_it = 0; res_it < res.rows.length; res_it++) {
                     let text = JSON.stringify([
                         res.rows[res_it].text,
+                        res.rows[res_it].text_tokenless,
                         res.rows[res_it]._text
                     ]);
 
@@ -177,7 +178,8 @@ class Cluster {
                         network
                     SET
                         text = '${text[0]}',
-                        _text = '${text[1]}',
+                        text_tokenless = '${text[1]}',
+                        _text = '${text[2]}',
                         named = TRUE
                     WHERE
                         id = ${id}

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -92,7 +92,7 @@ function serve(cb) {
             FROM
                 itp
             WHERE
-                ST_Contains(geom, ST_SetSRID(ST_MakePoint(${req.params.latlng.split(',')[0]}, ${req.params.latlng.split(',')[1]}), 4326))
+                ST_Intersects(geom, ST_SetSRID(ST_MakePoint(${req.params.latlng.split(',')[0]}, ${req.params.latlng.split(',')[1]}), 4326))
             ORDER BY
                 ST_Distance(
                     ST_ClosestPoint(

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const Carmen = require('@mapbox/carmen');
+const MBTiles = require('@mapbox/mbtiles');
+
+module.exports = localCarmen;
+function localCarmen(param) {
+    if (!param.index) throw new Error('param.index not specified');
+
+    const opts = {
+        address: new MBTiles(path.resolve(param.index), () => {})
+    };
+
+    if (param.getInfo.metadata) param.getInfo = param.getInfo.metadata; //Necessary for internal use
+
+    delete param.getInfo.tiles;
+    delete param.getInfo.geocdoer_data;
+    delete param.getInfo.geocoder_format;
+
+    opts.address.getInfo = (cb) => {
+        return cb(null, param.getInfo);
+    };
+
+    let carmen = new Carmen(opts);
+    return carmen;
+}
+
+if (require.main === module) {
+    let argv = require('minimist')(argv, {
+        string: [
+            'query',
+            'index',
+            'config',
+            'proximity'
+        ],
+        alias: {
+            query: 'q',
+            index: 'i',
+            config: 'c',
+            proximity: 'p'
+        }
+    });
+    if (!argv.query) {
+        console.error('--query=<QUERY> argument required');
+        process.exit(1);
+    } else if (!argv.index) {
+        console.error('--index=<INDEX.mbtiles> argument required');
+        process.exit(1);
+    } else if (!argv.config) {
+        console.error('--config=<CONFIG.json> argument required');
+        process.exit(1);
+    }
+
+    let c = localCarmen({ index: argv.index, getInfo: require(path.resolve(argv.config)) });
+
+    let opts = {};
+    if (argv.proximity)
+        opts.proximity = argv.proximity.split(',').map(parseFloat);
+
+    c.geocode(query, opts, (err, res) => {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+        console.log(JSON.stringify(res, null, 2));
+    });
+}

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const path = require('path');
 const Carmen = require('@mapbox/carmen');
 const MBTiles = require('@mapbox/mbtiles');
@@ -25,7 +27,7 @@ function localCarmen(param) {
 }
 
 if (require.main === module) {
-    let argv = require('minimist')(argv, {
+    let argv = require('minimist')(process.argv, {
         string: [
             'query',
             'index',
@@ -56,7 +58,7 @@ if (require.main === module) {
     if (argv.proximity)
         opts.proximity = argv.proximity.split(',').map(parseFloat);
 
-    c.geocode(query, opts, (err, res) => {
+    c.geocode(argv.query, opts, (err, res) => {
         if (err) {
             console.error(err);
             process.exit(1);

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,8 +27,8 @@ class Index {
                 DROP TABLE IF EXISTS meta;
                 DROP TABLE IF EXISTS address;
                 DROP TABLE IF EXISTS network;
-                CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number NUMERIC, lon TEXT, lat TEXT, geom GEOMETRY(POINTZ, 4326));
-                CREATE TABLE network (id SERIAL, text TEXT, _text TEXT, named BOOLEAN, geomtext TEXT, geom GEOMETRY(LINESTRING, 4326));
+                CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number NUMERIC, lon TEXT, lat TEXT, geom GEOMETRY(POINTZ, 4326));
+                CREATE TABLE network (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, named BOOLEAN, geomtext TEXT, geom GEOMETRY(LINESTRING, 4326));
                 CREATE TABLE meta (k TEXT UNIQUE, v TEXT);
                 COMMIT;
             `, (err, res) => {
@@ -146,8 +146,9 @@ class Index {
 
             feat.properties._text = title(feat.properties.street);                                  //The _text value is what is displayed to the user - it should not be modified after this
 
-            feat.properties.street = diacritics(tokenize.main(feat.properties.street, opts.tokens).join(' '));       //The street is standardized and it what is used to compare to the address cluster
-            feat.properties.steet = tokenize.replaceToken(tokenRegex, feat.properties.street);
+            let tokens = tokenize.main(feat.properties.street, opts.tokens, true);
+            feat.properties.street = diacritics(tokens.tokens.join(' '));       //The street is standardized and it what is used to compare to the address cluster
+            feat.properties.streetTokenless = diacritics(tokens.tokenless.join(' ')); // we will also use the tokenless form during the linker phase
 
             if (type === 'address') {
                 if (feat.properties.number === null) {
@@ -172,9 +173,9 @@ class Index {
                     feat.properties.number = num;
                 }
 
-                rl.output.write(`${this.str(feat.properties.street)}|${this.str(feat.properties._text)}|${JSON.stringify(this.str(feat.geometry.coordinates[0]))}|${JSON.stringify(this.str(feat.geometry.coordinates[1]))}|${this.str(feat.properties.number)}\n`);
+                rl.output.write(`${this.str(feat.properties.street)}|${this.str(feat.properties.streetTokenless)}|${this.str(feat.properties._text)}|${JSON.stringify(this.str(feat.geometry.coordinates[0]))}|${JSON.stringify(this.str(feat.geometry.coordinates[1]))}|${this.str(feat.properties.number)}\n`);
             } else {
-                rl.output.write(`${this.str(feat.properties.street)}|${this.str(feat.properties._text)}|${this.str(JSON.stringify(feat.geometry))}\n`);
+                rl.output.write(`${this.str(feat.properties.street)}|${this.str(feat.properties.streetTokenless)}|${this.str(feat.properties._text)}|${this.str(JSON.stringify(feat.geometry))}\n`);
             }
         });
 
@@ -187,8 +188,8 @@ class Index {
                 if (err) return cb(err);
 
                 let query;
-                if (type === 'address') query = `COPY address (text, _text, lon, lat, number) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
-                else query = `COPY network (text, _text, geomtext) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
+                if (type === 'address') query = `COPY address (text, text_tokenless, _text, lon, lat, number) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
+                else query = `COPY network (text, text_tokenless, _text, geomtext) FROM '${psv}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';`;
 
                 client.query(String(query), (err, res) => {
                     cb(err);

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -18,24 +18,24 @@ module.exports = (street, addresses) => {
             levScore = (0.25 * dist(street.text, address.text)) + (0.75 *  dist(street.text_tokenless, address.text_tokenless));
         }
         else {
-	    // text_tokenless is unavailable for one or more of the features, but text is nonempty (it is not an unnamed road).
-	    // this can be due to an edge case like 'Avenue Street' in which all words are tokens.
-	    // in this case, short-circuit if one string is fully contained within another.
-	    if (address.text && street.text) {
-		let shorter, longer;
-		if (street.text.length > address.text.length) {
-		    longer = street.text;
-		    shorter = address.text;
-		}
-		else {
-		    longer = address.text;
-		    shorter = street.text;
-		}
-		if (longer.indexOf(shorter) !== -1)
-		    return address;
-	    }
+            // text_tokenless is unavailable for one or more of the features, but text is nonempty (it is not an unnamed road).
+            // this can be due to an edge case like 'Avenue Street' in which all words are tokens.
+            // in this case, short-circuit if one string is fully contained within another.
+            if (address.text && street.text) {
+                let shorter, longer;
+                if (street.text.length > address.text.length) {
+                    longer = street.text;
+                    shorter = address.text;
+                }
+                else {
+                    longer = address.text;
+                    shorter = street.text;
+                }
+                if (longer.indexOf(shorter) !== -1)
+                    return address;
+                }
 
-	    levScore = dist(street.text, address.text);
+            levScore = dist(street.text, address.text);
         }
 
         //Calculate % Match

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -12,10 +12,31 @@ module.exports = (street, addresses) => {
         //Short Circuit if the text is exactly the same
         if (address.text === street.text) return address;
 
-        let levScore = dist(street.text, address.text);
         // use a weighted average w/ the tokenless dist score if possible
-        if (street.text_tokenless && address.text_tokenless)
-            levScore = (0.25 * levScore) + (0.75 *  dist(street.text_tokenless, address.text_tokenless));
+        let levScore;
+        if (street.text_tokenless && address.text_tokenless) {
+            levScore = (0.25 * dist(street.text, address.text)) + (0.75 *  dist(street.text_tokenless, address.text_tokenless));
+        }
+        else {
+	    // text_tokenless is unavailable for one or more of the features, but text is nonempty (it is not an unnamed road).
+	    // this can be due to an edge case like 'Avenue Street' in which all words are tokens.
+	    // in this case, short-circuit if one string is fully contained within another.
+	    if (address.text && street.text) {
+		let shorter, longer;
+		if (street.text.length > address.text.length) {
+		    longer = street.text;
+		    shorter = address.text;
+		}
+		else {
+		    longer = address.text;
+		    shorter = street.text;
+		}
+		if (longer.indexOf(shorter) !== -1)
+		    return address;
+	    }
+
+	    levScore = dist(street.text, address.text);
+        }
 
         //Calculate % Match
         let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -13,9 +13,11 @@ module.exports = (street, addresses) => {
         if (address.text === street.text) return address;
 
         let levScore = dist(street.text, address.text);
+        let levScoreTokenless = dist(street.text_tokenless, address.text_tokenless);
+        let composite = (0.25 * levScore) + (0.75 * levScoreTokenless);
 
         //Calculate % Match
-        let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)
+        let score = 100 - (((2 * composite) / (address.text.length + street.text.length)) * 100)
 
         if (!current || current.score < score) {
             current = {

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -13,11 +13,12 @@ module.exports = (street, addresses) => {
         if (address.text === street.text) return address;
 
         let levScore = dist(street.text, address.text);
-        let levScoreTokenless = dist(street.text_tokenless, address.text_tokenless);
-        let composite = (0.25 * levScore) + (0.75 * levScoreTokenless);
+        // use a weighted average w/ the tokenless dist score if possible
+        if (street.text_tokenless && address.text_tokenless)
+            levScore = (0.25 * levScore) + (0.75 *  dist(street.text_tokenless, address.text_tokenless));
 
         //Calculate % Match
-        let score = 100 - (((2 * composite) / (address.text.length + street.text.length)) * 100)
+        let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)
 
         if (!current || current.score < score) {
             current = {

--- a/lib/map.js
+++ b/lib/map.js
@@ -65,7 +65,7 @@ module.exports = function(argv, cb) {
 
         let parsed = [];
         argv.tokens.forEach((token) => {
-            parsed = parsed.concat(tokens(token));
+            parsed = parsed.concat(tokens(token, true)); // pull singletons in, too -- ie tokens that are common but have no abbreviation
         });
 
         let parsedTokens = {};

--- a/lib/map.js
+++ b/lib/map.js
@@ -73,17 +73,11 @@ module.exports = function(argv, cb) {
             parse.sort((a, b) => {
                 return a.length > b.length
             });
-            if (parse.length === 1) {
-                throw new Error('tokens must be in a min group of two');
-            } else if (parse.length > 2) {
-                parse.forEach((token, it) => {
-                    if (it === 0) return;
 
-                    parsedTokens[token.toLowerCase()] = parse[0].toLowerCase();
-                });
-            } else {
-                parsedTokens[parse[1].toLowerCase()] = parse[0].toLowerCase();
-            }
+            // we intentionally mark the smallest token as a replacement for itself
+            // this seems silly but it lets us exclude it from text_tokenless in cases where it's pre-abbreviated
+            for(let pi = 0; pi < parse.length; pi++)
+                parsedTokens[parse[pi].toLowerCase()] = parse[0].toLowerCase();
 
             argv.tokens = parsedTokens;
         });

--- a/lib/map.js
+++ b/lib/map.js
@@ -76,7 +76,7 @@ module.exports = function(argv, cb) {
 
             // we intentionally mark the smallest token as a replacement for itself
             // this seems silly but it lets us exclude it from text_tokenless in cases where it's pre-abbreviated
-            for(let pi = 0; pi < parse.length; pi++)
+            for (let pi = 0; pi < parse.length; pi++)
                 parsedTokens[parse[pi].toLowerCase()] = parse[0].toLowerCase();
 
             argv.tokens = parsedTokens;

--- a/lib/test.js
+++ b/lib/test.js
@@ -12,7 +12,7 @@ const geocode = require('./geocode');
 const tokens = require('@mapbox/geocoder-abbreviations');
 
 const Index = require('./index');
-const tokenize = require('./tokenize');
+const tokenize = require('./tokenize').main;
 
 //Use raw addresses to query generated ITP output to check for completeness
 function test(argv, cb) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -90,7 +90,7 @@ function test(argv, cb) {
                         complete: '=',
                         incomplete: ' ',
                         width: 20,
-                        total: res.rows[0].count++
+                        total: argv.limit || res.rows[0].count++
                     });
                     bar.tick(1);
 
@@ -184,7 +184,7 @@ function test(argv, cb) {
                         complete: '=',
                         incomplete: ' ',
                         width: 20,
-                        total: res.rows[0].count++
+                        total: argv.limit || res.rows[0].count++
                     });
                     bar.tick(1);
 
@@ -234,7 +234,7 @@ function test(argv, cb) {
                         complete: '=',
                         incomplete: ' ',
                         width: 20,
-                        total: res.rows[0].count++
+                        total: argv.limit || res.rows[0].count++
                     });
                     bar.tick(1);
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -6,10 +6,9 @@ const path = require('path');
 const prog = require('progress');
 const turf = require('@turf/turf');
 const Cursor = require('pg-cursor');
-const Carmen = require('@mapbox/carmen');
-const MBTiles = require('@mapbox/mbtiles');
 const Queue = require('d3-queue').queue;
 const diacritics = require('diacritics').remove;
+const geocode = require('./geocode');
 
 const Index = require('./index');
 const tokenize = require('./tokenize');
@@ -45,13 +44,6 @@ function test(argv, cb) {
         process.exit(1);
     }
 
-    let cnf = require(path.resolve(argv.config));
-    if (cnf.metadata) cnf = cnf.metadata; //Necessary for internal use
-
-    delete cnf.tiles;
-    delete cnf.geocdoer_data;
-    delete cnf.geocoder_format;
-
     const pool = new pg.Pool({
         max: 10,
         user: 'postgres',
@@ -62,18 +54,15 @@ function test(argv, cb) {
     const index = new Index(pool);
 
     const opts = {
-        address: new MBTiles(path.resolve(argv.index), () => {})
+        getInfo: require(path.resolve(argv.config)),
+        index: argv.index
     };
+    const c = geocode(opts);
 
-    opts.address.getInfo = (cb) => {
-        return cb(null, cnf);
-    };
-
-    const c = new Carmen(opts);
     const stats = {
         fail: 0,
         total: 0
-    }
+    };
 
     const cursor_it = 5; //Number of rows to grab at a time from postgres;
 
@@ -176,7 +165,7 @@ function test(argv, cb) {
                                 setImmediate(iterate);
                             });
                         });
-                    } 
+                    }
 
                 });
             }
@@ -226,7 +215,7 @@ function test(argv, cb) {
                             bar.tick(cursor_it);
                             setImmediate(iterate);
                         });
-                    } 
+                    }
 
                 });
             }
@@ -278,7 +267,7 @@ function test(argv, cb) {
                             bar.tick(cursor_it);
                             setImmediate(iterate);
                         });
-                    } 
+                    }
 
                 });
             }

--- a/lib/test.js
+++ b/lib/test.js
@@ -132,7 +132,7 @@ function test(argv, cb) {
 
                                             let dist = false;
                                             if (res.features[0].geometry.type === 'Point') {
-                                                dist = turf.distance(res.features[0], opts.proximity, 'kilometers');
+                                                dist = turf.distance(res.features[0].geometry.coordinates, opts.proximity, 'kilometers');
                                             }
 
                                             if (matched !== cleanQuery) {
@@ -141,7 +141,7 @@ function test(argv, cb) {
                                             } else if (dist && dist > 1) {
                                                 stats.fail++;
                                                 return done(null, `DIST FAIL - ${dist.toFixed(2)}km - returned: ${res.features[0].geometry.coordinates}|${query}|${opts.proximity.join(',')}`);
-                                            } else if (!dist) { //Usually a street level result
+                                            } else if (dist === false) { //Usually a street level result
                                                 stats.fail++;
                                                 return done(null, `DIST FAIL|${query}|${opts.proximity.join(',')}`);
                                             }

--- a/lib/test.js
+++ b/lib/test.js
@@ -21,11 +21,13 @@ function test(argv, cb) {
                 'database',
                 'index',
                 'output',
-                'config'
+                'config',
+                'limit'
             ],
             alias: {
                 database: 'db',
-                output: 'o'
+                output: 'o',
+		limit: 'l'
             }
         });
     }
@@ -43,6 +45,7 @@ function test(argv, cb) {
         console.error('--config=<CONFIG.json> argument required');
         process.exit(1);
     }
+    if (argv.limit) argv.limit = parseInt(argv.limit);
 
     const pool = new pg.Pool({
         max: 10,

--- a/lib/test.js
+++ b/lib/test.js
@@ -27,7 +27,7 @@ function test(argv, cb) {
             alias: {
                 database: 'db',
                 output: 'o',
-		limit: 'l'
+                limit: 'l'
             }
         });
     }
@@ -84,7 +84,7 @@ function test(argv, cb) {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;', (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL;'));
+                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
 
                     const bar = new prog('ok - Testing Network Matched Addresses [:bar] :percent :etas', {
                         complete: '=',
@@ -178,7 +178,7 @@ function test(argv, cb) {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;'));
+                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
 
                     const bar = new prog('ok - Unmatched Addresses [:bar] :percent :etas', {
                         complete: '=',
@@ -228,7 +228,7 @@ function test(argv, cb) {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text;', (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text AS atext, n._text AS ntext, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text;'));
+                    const cursor = client.query(new Cursor('SELECT a._text AS atext, n._text AS ntext, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL AND n._text != a._text' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
 
                     const bar = new prog('ok - Name Mismatch [:bar] :percent :etas', {
                         complete: '=',

--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -13,8 +13,9 @@ const _ = require('lodash');
  * @return {Array}         A tokenized array
  */
 
-function main(query, replacer) {
+function main(query, replacer, complex) {
     if (!replacer) replacer = {};
+    complex = !!complex;
 
     let normalized = query
         .toLowerCase()
@@ -38,6 +39,7 @@ function main(query, replacer) {
     }
 
     let tokens = [];
+    let tokenless = [];
 
     for (let i = 0; i < pretokens.length; i++) {
         if (pretokens[i].length) {
@@ -46,12 +48,16 @@ function main(query, replacer) {
     }
 
     for (let i = 0; i < tokens.length; i++) {
-        if (replacer[tokens[i]]) {
+        if (replacer[tokens[i]])
             tokens[i] = replacer[tokens[i]];
-        }
+        else
+            tokenless.push(tokens[i]);
     }
 
-    return tokens;
+    if (complex)
+        return { tokens: tokens, tokenless: tokenless };
+    else
+        return tokens;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@mapbox/carmen": "^22.2.0",
-    "@mapbox/geocoder-abbreviations": "^1.2.0",
+    "@mapbox/geocoder-abbreviations": "^1.4.0",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "9.18.0",
+  "version": "9.19.0",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@mapbox/carmen": "^22.2.0",
-    "@mapbox/geocoder-abbreviations": "1.0.2",
+    "@mapbox/geocoder-abbreviations": "^1.2.0",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",

--- a/test/cluster.clusterWithin.test.js
+++ b/test/cluster.clusterWithin.test.js
@@ -24,7 +24,7 @@ test('Points far away shouldn\'t be clustered', (t) => {
             DROP TABLE IF EXISTS address_cluster;
             DROP TABLE IF EXISTS network;
             DROP TABLE IF EXISTS network_cluster;
-            CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
+            CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -36,8 +36,8 @@ test('Points far away shouldn\'t be clustered', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address (id, text, _text, number, geom) VALUES (1, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [9.505233764648438,47.13018433161339 ] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (2, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [9.523429870605469,47.130797460977575 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (1, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [9.505233764648438,47.13018433161339 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (2, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [9.523429870605469,47.130797460977575 ] }'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -78,7 +78,7 @@ test('Points nearby should be clustered', (t) => {
             BEGIN;
             DROP TABLE IF EXISTS address;
             DROP TABLE IF EXISTS address_cluster;
-            CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
+            CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -90,8 +90,8 @@ test('Points nearby should be clustered', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address (id, text, _text, number, geom) VALUES (1, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [ 9.51413869857788,47.132724392963944 ]}'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (2, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [ 9.516541957855225,47.132724392963944 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (1, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [ 9.51413869857788,47.132724392963944 ]}'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (2, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point","coordinates": [ 9.516541957855225,47.132724392963944 ] }'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -132,7 +132,7 @@ test('LinesStrings far away should not be clustered', (t) => {
         pool.query(`
             BEGIN;
             DROP TABLE IF EXISTS network;
-            CREATE TABLE network (id SERIAL, text TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
+            CREATE TABLE network (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -144,8 +144,8 @@ test('LinesStrings far away should not be clustered', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO network (id, text, _text, geom) VALUES (1, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.50514793395996,47.13027192195532],[9.50094223022461,47.13027192195532]]}'), 4326));
-            INSERT INTO network (id, text, _text, geom) VALUES (2, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.523429870605469,47.1308412556617],[9.527077674865723,47.13091424672175]]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless, _text, geom) VALUES (1, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.50514793395996,47.13027192195532],[9.50094223022461,47.13027192195532]]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless, _text, geom) VALUES (2, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.523429870605469,47.1308412556617],[9.527077674865723,47.13091424672175]]}'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -186,10 +186,10 @@ test('LinesStrings should be clustered', (t) => {
             DROP TABLE IF EXISTS address_cluster;
             DROP TABLE IF EXISTS network;
             DROP TABLE IF EXISTS network_cluster;
-            CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
-            CREATE TABLE address_cluster (id SERIAL, text TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
-            CREATE TABLE network (id SERIAL, text TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
-            CREATE TABLE network_cluster (id SERIAL, text TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
+            CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
+            CREATE TABLE address_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
+            CREATE TABLE network (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
+            CREATE TABLE network_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -201,8 +201,8 @@ test('LinesStrings should be clustered', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO network (id, text, _text, geom) VALUES (1, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString","coordinates": [[9.516735076904297,47.13276818606133],[9.519824981689451,47.132870369814995]]}'), 4326));
-            INSERT INTO network (id, text, _text, geom) VALUES (2, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.513999223709106,47.132695197545665],[9.512518644332886,47.132695197545665]]},'), 4326));
+            INSERT INTO network (id, text, text_tokenless, _text, geom) VALUES (1, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString","coordinates": [[9.516735076904297,47.13276818606133],[9.519824981689451,47.132870369814995]]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless,_text, geom) VALUES (2, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{"type": "LineString", "coordinates": [[9.513999223709106,47.132695197545665],[9.512518644332886,47.132695197545665]]},'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -21,10 +21,10 @@ test('cluster.name', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
-            CREATE TABLE address_cluster (id SERIAL, text TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
-            CREATE TABLE network (id SERIAL, text TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
-            CREATE TABLE network_cluster (id SERIAL, text TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
+            CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
+            CREATE TABLE address_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
+            CREATE TABLE network (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, named BOOLEAN, geom GEOMETRY(LINESTRING, 4326));
+            CREATE TABLE network_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -48,10 +48,10 @@ test('cluster.name', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address (id, text, _text, number, geom) VALUES (1, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (2, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05125308036804, 45.26868759094269 ] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (3, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05092048645020, 45.26872912017898 ] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (4, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05050742626190, 45.26880462780347 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (1, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (2, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05125308036804, 45.26868759094269 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (3, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05092048645020, 45.26872912017898 ] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (4, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05050742626190, 45.26880462780347 ] }'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -68,13 +68,14 @@ test('cluster.name', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, _text, text, named FROM network;
+            SELECT id, _text, text_tokenless, text, named FROM network;
         `, (err, res) => {
             t.error(err);
 
             t.deepEquals(res.rows[0], {
                 id: 1,
                 _text: 'Main Street',
+                text_tokenless: 'main',
                 text: 'main st',
                 named: true
             });
@@ -106,8 +107,8 @@ test('cluster.match', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            CREATE TABLE address_cluster (id SERIAL, text TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
-            CREATE TABLE network_cluster (id SERIAL, text TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
+            CREATE TABLE address_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number TEXT, geom GEOMETRY(MULTIPOINT, 4326));
+            CREATE TABLE network_cluster (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, address INT, geom GEOMETRY(MULTILINESTRING, 4326), buffer GEOMETRY(POLYGON, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -119,7 +120,7 @@ test('cluster.match', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO network_cluster (id, text, _text, geom) VALUES (1, 'main st', 'Main Street', ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05180561542511, 45.26869136632906 ], [ -66.05007290840149, 45.268982070325656 ] ] }'), 4326)));
+            INSERT INTO network_cluster (id, text, text_tokenless, _text, geom) VALUES (1, 'main st', 'main', 'Main Street', ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05180561542511, 45.26869136632906 ], [ -66.05007290840149, 45.268982070325656 ] ] }'), 4326)));
             UPDATE network_cluster SET buffer = ST_Buffer(ST_Envelope(geom), 0.01);
             COMMIT;
         `, (err, res) => {
@@ -132,8 +133,8 @@ test('cluster.match', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address_cluster (id, text, _text, number, geom) VALUES (1, 'main st', 'Main Street', 10, ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326)));
-            INSERT INTO address_cluster (id, text, _text, number, geom) VALUES (2, 'fake av', 'Fake Avenue', 12, ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326)));
+            INSERT INTO address_cluster (id, text, text_tokenless, _text, number, geom) VALUES (1, 'main st', 'main', 'Main Street', 10, ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326)));
+            INSERT INTO address_cluster (id, text, text_tokenless, _text, number, geom) VALUES (2, 'fake av', 'fake', 'Fake Avenue', 12, ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326)));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -150,13 +151,14 @@ test('cluster.match', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, text, address FROM network_cluster;
+            SELECT id, text, text_tokenless, address FROM network_cluster;
         `, (err, res) => {
             t.error(err);
 
             t.deepEquals(res.rows[0], {
                 id: 1,
                 text: 'main st',
+                text_tokenless: 'main',
                 address: 1
             });
             return done();
@@ -185,7 +187,7 @@ test('cluster.address', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            CREATE TABLE address (id SERIAL, text TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
+            CREATE TABLE address (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, number INT, geom GEOMETRY(POINT, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -197,11 +199,11 @@ test('cluster.address', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address (id, text, _text, number, geom) VALUES (1, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-66.97265625,43.96119063892024] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (2, 'main st', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-66.97265625,43.96119063892024] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (3, 'main st', 'Main Street', 13, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-105.46875,56.36525013685606] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (4, 'main st', 'Main Street', 13, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-105.46875,56.36525013685606] }'), 4326));
-            INSERT INTO address (id, text, _text, number, geom) VALUES (5, 'fake av', 'Fake Avenue', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-85.25390625,52.908902047770255] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (1, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-66.97265625,43.96119063892024] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (2, 'main st', 'main', 'Main Street', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-66.97265625,43.96119063892024] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (3, 'main st', 'main', 'Main Street', 13, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-105.46875,56.36525013685606] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (4, 'main st', 'main', 'Main Street', 13, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-105.46875,56.36525013685606] }'), 4326));
+            INSERT INTO address (id, text, text_tokenless, _text, number, geom) VALUES (5, 'fake av', 'fake', 'Fake Avenue', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [-85.25390625,52.908902047770255] }'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -218,14 +220,14 @@ test('cluster.address', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, text, ST_AsGeoJSON(geom) AS geom FROM address_cluster ORDER BY text, id;
+            SELECT id, text, text_tokenless, ST_AsGeoJSON(geom) AS geom FROM address_cluster ORDER BY text, id;
         `, (err, res) => {
             t.error(err);
 
             t.equals(res.rows.length, 3);
-            t.deepEquals(res.rows[0], { geom: '{"type":"MultiPoint","coordinates":[[-85.25390625,52.9089020477703]]}', id: 1, text: 'fake av' }, 'fake av');
-            t.deepEquals(res.rows[1], { geom: '{"type":"MultiPoint","coordinates":[[-66.97265625,43.9611906389202],[-66.97265625,43.9611906389202]]}', id: 2, text: 'main st' });
-            t.deepEquals(res.rows[2], { geom: '{"type":"MultiPoint","coordinates":[[-105.46875,56.3652501368561],[-105.46875,56.3652501368561]]}', id: 3, text: 'main st' });
+            t.deepEquals(res.rows[0], { geom: '{"type":"MultiPoint","coordinates":[[-85.25390625,52.9089020477703]]}', id: 1, text: 'fake av', text_tokenless: 'fake' }, 'fake av');
+            t.deepEquals(res.rows[1], { geom: '{"type":"MultiPoint","coordinates":[[-66.97265625,43.9611906389202],[-66.97265625,43.9611906389202]]}', id: 2, text: 'main st', text_tokenless: 'main' });
+            t.deepEquals(res.rows[2], { geom: '{"type":"MultiPoint","coordinates":[[-105.46875,56.3652501368561],[-105.46875,56.3652501368561]]}', id: 3, text: 'main st', text_tokenless: 'main' });
             return done();
         });
     });
@@ -252,7 +254,7 @@ test('cluster.network', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            CREATE TABLE network (id SERIAL, text TEXT, _text TEXT, geom GEOMETRY(LINESTRING, 4326));
+            CREATE TABLE network (id SERIAL, text TEXT, text_tokenless TEXT, _text TEXT, geom GEOMETRY(LINESTRING, 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -264,10 +266,10 @@ test('cluster.network', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO network (id, text, _text, geom) VALUES (1, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05390310287476, 45.26961632842303 ], [ -66.05441808700562, 45.271035832768376 ] ]}'), 4326));
-            INSERT INTO network (id, text, _text, geom) VALUES (2, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05435371398926, 45.27100563091792 ], [ -66.05493307113646, 45.27245530161207 ] ]}'), 4326));
-            INSERT INTO network (id, text, _text, geom) VALUES (3, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -113.50117206573485, 53.55137413785917 ], [ -113.50112915039062, 53.54836549323335 ] ]}'), 4326));
-            INSERT INTO network (id, text, _text, geom) VALUES (4, 'main st', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -113.50100040435791, 53.54836549323335 ], [ -113.50104331970215, 53.54614711825744 ] ]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless, _text, geom) VALUES (1, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05390310287476, 45.26961632842303 ], [ -66.05441808700562, 45.271035832768376 ] ]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless,_text, geom) VALUES (2, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -66.05435371398926, 45.27100563091792 ], [ -66.05493307113646, 45.27245530161207 ] ]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless,_text, geom) VALUES (3, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -113.50117206573485, 53.55137413785917 ], [ -113.50112915039062, 53.54836549323335 ] ]}'), 4326));
+            INSERT INTO network (id, text, text_tokenless,_text, geom) VALUES (4, 'main st', 'main', 'Main Street', ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "LineString", "coordinates": [ [ -113.50100040435791, 53.54836549323335 ], [ -113.50104331970215, 53.54614711825744 ] ]}'), 4326));
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -284,13 +286,13 @@ test('cluster.network', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, text, ST_AsGeoJSON(geom) AS geom FROM network_cluster;
+            SELECT id, text, text_tokenless, ST_AsGeoJSON(geom) AS geom FROM network_cluster;
         `, (err, res) => {
             t.error(err);
 
             t.equals(res.rows.length, 2);
-            t.deepEquals(res.rows[0], { geom: '{"type":"MultiLineString","coordinates":[[[-66.0539031028748,45.269616328423],[-66.0544180870056,45.2710358327684]],[[-66.0543537139893,45.2710056309179],[-66.0549330711365,45.2724553016121]]]}', id: 1, text: 'main st' });
-            t.deepEquals(res.rows[1], { geom: '{"type":"MultiLineString","coordinates":[[[-113.501172065735,53.5513741378592],[-113.501129150391,53.5483654932333]],[[-113.501000404358,53.5483654932333],[-113.501043319702,53.5461471182574]]]}', id: 2, text: 'main st' });
+            t.deepEquals(res.rows[0], { geom: '{"type":"MultiLineString","coordinates":[[[-66.0539031028748,45.269616328423],[-66.0544180870056,45.2710358327684]],[[-66.0543537139893,45.2710056309179],[-66.0549330711365,45.2724553016121]]]}', id: 1, text: 'main st', text_tokenless: 'main' });
+            t.deepEquals(res.rows[1], { geom: '{"type":"MultiLineString","coordinates":[[[-113.501172065735,53.5513741378592],[-113.501129150391,53.5483654932333]],[[-113.501000404358,53.5483654932333],[-113.501043319702,53.5461471182574]]]}', id: 2, text: 'main st',  text_tokenless: 'main' });
             return done();
         });
     });

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -36,6 +36,22 @@ test('Passing Linker Matches', (t) => {
         { id: 1, text: 'main st' },
     'diff name');
 
+    t.deepEquals(
+        linker({ text: 'ola ave', text_tokenless: 'ola' }, [
+            { id: 1, text: 'ola', text_tokenless: 'ola'},
+            { id: 2, text: 'ola avg', text_tokenless: 'ola avg'}
+        ]),
+        { id: 1, text: 'ola', text_tokenless: 'ola'},
+    'short names, tokens deweighted');
+
+    t.deepEquals(
+        linker({ text: 'ave st', text_tokenless: '' }, [
+            { id: 1, text: 'ave', text_tokenless: ''},
+            { id: 2, text: 'avenida', text_tokenless: 'avenida'}
+        ]),
+        { id: 1, text: 'ave', text_tokenless: ''},
+    'all-token scenario (e.g. avenue street)');
+
     t.end();
 });
 

--- a/web/index.html
+++ b/web/index.html
@@ -227,23 +227,25 @@
 
             $search.val(res.properties['carmen:text']);
 
-            let segs = res.geometry.geometries[0].coordinates.map((line, it) => {
-                return turf.lineString(line, {
-                    colour: Math.floor(Math.random() * 11),
-                    lfromhn: res.properties['carmen:lfromhn'][0][it],
-                    ltohn: res.properties['carmen:ltohn'][0][it],
-                    rfromhn: res.properties['carmen:rfromhn'][0][it],
-                    rtohn: res.properties['carmen:rtohn'][0][it],
-                    parityl: res.properties['carmen:parityl'][0][it],
-                    parityr: res.properties['carmen:parityr'][0][it]
-                });
-            });
+	    if (res.properties['carmen:lfromhn']) {
+		let segs = res.geometry.geometries[0].coordinates.map((line, it) => {
+		    return turf.lineString(line, {
+			colour: Math.floor(Math.random() * 11),
+			lfromhn: res.properties['carmen:lfromhn'][0][it],
+			ltohn: res.properties['carmen:ltohn'][0][it],
+			rfromhn: res.properties['carmen:rfromhn'][0][it],
+			rtohn: res.properties['carmen:rtohn'][0][it],
+			parityl: res.properties['carmen:parityl'][0][it],
+			parityr: res.properties['carmen:parityr'][0][it]
+		    });
+		});
+		//Process ITP Geom
+		map.getSource('itp').setData({
+		    type: 'FeatureCollection',
+		    features: segs
+		});
+	    }
 
-            //Process ITP Geom
-            map.getSource('itp').setData({
-                type: 'FeatureCollection',
-                features: segs
-            });
 
             if (res.debug) {
                 let debug = [];


### PR DESCRIPTION
cc @ingalls

- :rocket: adds a `lib/geocode.js` that takes `lib/test.js`-like set of parameters to geocode a single query
- :rocket: modularizes geocoding capability too
- :tada: adds `--limit` param to `test.js`
- :rocket: weight linker comparisons to deemphasize mismatches based purely on tokens
    - adds `text_tokenless` column to `address_cluster` & `network_cluster` tables
    - handle all-token special case by checking for substring status
- :rocket: detection of candidate address_clusters now uses `ST_Intersects` instead of `ST_Contains`
- :bug: fix JS error in web interface related to features w/o itp data