### PR TITLE
add highway=(construction|proposed|footway)

### DIFF
--- a/lib/map/minjur.js
+++ b/lib/map/minjur.js
@@ -24,7 +24,10 @@ module.exports.map = function(feat) {
         'pedestrian',
         'service',
         'track',
-        'road'
+        'road',
+        'construction',
+        'proposed',
+        'footway'
     ];
 
     //Eliminate all highway types not on accepted list
@@ -49,8 +52,8 @@ module.exports.map = function(feat) {
     if (!names.length) names = '';
     else if (names.length === 1) names = names[0]; //String for 1 value array for many
 
-    if (['track', 'service'].indexOf(feat.properties.highway) && !names.length) {
-        return false; //Track and service roads should only be allowed if they are already named
+    if (['track', 'service', 'construction', 'proposed', 'footway'].indexOf(feat.properties.highway) && !names.length) {
+        return false; // these classes of roads should only be allowed if they are already named
     }
 
     return {


### PR DESCRIPTION
Official Estonian open address points have records for addresses on some ways that are present in OSM but seemingly not up to date: they are either under construction or planned, according to OSM. Checking against satellite imagery from various providers shows that some of these roads exist already, some are indeed under construction and some are empty forest.

Still, it seems likely that the presence of an official record indicates a location that people would like to be able to find -- potentially even if it doesn't yet exist. Unless it introduces false positives, we should geocode these.

per conversation with @ingalls, I've added three new tags but limited newly-admitted ways to ones that have names (these ways will _not_ be eligible for automatic naming based on input address data).