### PR TITLE
fix all-token comparison

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -107,8 +107,10 @@ class Cluster {
             SELECT
                 network.text AS network,
                 network.text_tokenless AS network_text_tokenless,
+                network._text AS network_text,
                 addr.id,
                 addr.text,
+                addr._text AS _text,
                 addr.text_tokenless AS text_tokenless
             FROM
                 address_cluster addr,
@@ -124,6 +126,7 @@ class Cluster {
             let address = linker({
                 id: id,
                 text: res.rows[0].network,
+                _text: res.rows[0].network_text,
                 text_tokenless: res.rows[0].network_text_tokenless
             }, res.rows)
 

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -1,4 +1,5 @@
 const dist = require('fast-levenshtein').get;
+const diacritics = require('diacritics').remove
 
 /**
  * Generates a map of street => address
@@ -21,15 +22,15 @@ module.exports = (street, addresses) => {
             // text_tokenless is unavailable for one or more of the features, but text is nonempty (it is not an unnamed road).
             // this can be due to an edge case like 'Avenue Street' in which all words are tokens.
             // in this case, short-circuit if one string is fully contained within another.
-            if (address.text && street.text) {
+            if (address._text && street._text) {
                 let shorter, longer;
-                if (street.text.length > address.text.length) {
-                    longer = street.text;
-                    shorter = address.text;
+                if (street._text.length > address._text.length) {
+                    longer = diacritics(street._text).toLowerCase();
+                    shorter = diacritics(address._text).toLowerCase();
                 }
                 else {
-                    longer = address.text;
-                    shorter = street.text;
+                    shorter = diacritics(street._text).toLowerCase();
+                    longer = diacritics(address._text).toLowerCase();
                 }
                 if (longer.indexOf(shorter) !== -1)
                     return address;

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -45,11 +45,11 @@ test('Passing Linker Matches', (t) => {
     'short names, tokens deweighted');
 
     t.deepEquals(
-        linker({ text: 'ave st', text_tokenless: '' }, [
-            { id: 1, text: 'ave', text_tokenless: ''},
+        linker({ text: 'ave st', text_tokenless: '', _text: 'Avenue Street' }, [
+            { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
             { id: 2, text: 'avenida', text_tokenless: 'avenida'}
         ]),
-        { id: 1, text: 'ave', text_tokenless: ''},
+        { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
     'all-token scenario (e.g. avenue street)');
 
     t.end();


### PR DESCRIPTION
The basic idea behind the all-token (eg `Avenue Street`) case proved sound, but the algorithm wasn't being given the fields it needed. This PR resolves that issue:

- exposes `_text` fields for comparison
- removes diacritics & lcases
