### PR TITLE
Fix empty array bug in strip mode

### DIFF
--- a/lib/strip.js
+++ b/lib/strip.js
@@ -57,6 +57,8 @@ module.exports = function(argv, cb) {
             i--;
         }
 
+        if (!feat.geometry.geometries.length) return;
+
         return rl.output.write(JSON.stringify(feat) + '\n');
     });
 


### PR DESCRIPTION
- :bug: `strip` mode - Don't ouput geometry if it was only points - empty array