### PR TITLE
revise child process stdout handling to avoid colliding JSON

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -16,6 +16,7 @@ const Index = require('./index');
 
 const buffer = require('./buffer');
 const split = require('./split');
+const linesplit = require('split');
 const misc = require('./misc');
 
 module.exports = function(argv, cb) {
@@ -348,9 +349,11 @@ module.exports = function(argv, cb) {
                     child.stdout.on('error', epipe);
                     child.stderr.on('error', epipe);
 
-                    child.stdout.pipe(output, {
-                        end: false
-                    });
+                    child.stdout
+			.pipe(linesplit())
+			.on('data', (line) => {
+			    output.write(line + '\n');
+			});
                     child.stderr.pipe(process.stderr);
 
                     child.on('message', (message) => {

--- a/lib/split.js
+++ b/lib/split.js
@@ -134,9 +134,7 @@ function split(nid, cb) {
             country: opts.country
         });
 
-        process.stdout.write(JSON.stringify(potential) + '\n');
-
-        return cb();
+        process.stdout.write(JSON.stringify(potential) + '\n', cb);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pg": "^6.1.0",
     "pg-cursor": "^1.0.1",
     "progress": "^2.0.0",
+    "split": "^1.0.0",
     "to-title-case": "^1.0.0",
     "turf-line-slice-at-intersection": "^1.0.1",
     "wellknown": "^0.5.0"


### PR DESCRIPTION
I've intermittently seen indexing fail on invalid JSON. Investigation shows what looks like `Feature`s dropped in the middle of other `Feature`s. I suspect a byproduct of the process by which numerous child workers' stdouts are piped to the same writestream.

This PR does two things to resolve the issue:
- uses the callback functionality of `process.stdout.write` to throttle writing so that it only occurs after the previous write is flushed. I don't think this helps but it's not a bad idea.
- uses the `split` module in the parent/orchestrating process to (hopefully) only write whole-line chunks to the output file

This appears to have resolved the issue for me, so I'm inclined to merge. However @ingalls is having a hard time replicating and in general this bug is a little :ghost:y.