### PR TITLE
🚀  Zoom to map bounds on first open of debug

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -84,6 +84,20 @@ function serve(cb) {
         });
     });
 
+    router.get('/bounds', (req, res, next) => {
+        pool.query(`
+            SELECT ST_Extent(geom) AS bounds FROM itp;
+        `, (err, bounds) => {
+            if (err) return cb(err);
+
+            let bb = bounds.rows[0].bounds.replace('BOX(', '').replace(')','').split(',').map((coords) => {
+                return coords.split(' ');
+            });
+
+            res.send(bb);
+        });
+    });
+
     router.get('/coords/:latlng', (req, res, next) => {
 
         pool.query(`

--- a/web/index.html
+++ b/web/index.html
@@ -161,7 +161,13 @@
                 }
             });
 
-            if ($search.val()) getID($search.val());
+            if ($search.val()) {
+                getID($search.val());
+            } else {
+                $.get('/api/bounds', (res) => {
+                    map.fitBounds(res);
+                }); 
+            }
         });
 
         map.on('click', (e) => {


### PR DESCRIPTION
It was driving me nuts having to geocode the country I am working on each time I use `debug` mode.

This auto zooms to the country that is loaded if there is no `id` that is in the URL string. IE on a clean load.

cc/ @sbma44 