### PR TITLE
[ready] optimize adoption query

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -73,6 +73,7 @@ class Cluster {
 		ALTER TABLE network_cluster ADD COLUMN address_text TEXT;
 		UPDATE network_cluster n SET address_text=a._text FROM address_cluster a WHERE n.address = a.id;
 		ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT;
+		CREATE INDEX orphan_adoptive_parent_idx ON address_cluster (orphan_adoptive_parent);
 		UPDATE address_cluster a SET orphan_adoptive_parent=n.address FROM network_cluster n WHERE (a._text=n.address_text AND ST_Intersects(n.buffer, a.geom) AND a.id NOT IN (SELECT address FROM network_cluster WHERE address IS NOT NULL)) OR (a.id=n.address);
 		CREATE TEMPORARY TABLE orphan_groups ON COMMIT DROP AS SELECT orphan_adoptive_parent, ST_CollectionExtract(ST_Collect(geom),1) AS geom FROM address_cluster GROUP BY orphan_adoptive_parent;
 		UPDATE address_cluster a SET geom=o.geom FROM orphan_groups o WHERE o.orphan_adoptive_parent=a.id;

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -74,6 +74,8 @@ class Cluster {
 		UPDATE network_cluster n SET address_text=a._text FROM address_cluster a WHERE n.address = a.id;
 		ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT;
 		CREATE INDEX orphan_adoptive_parent_idx ON address_cluster (orphan_adoptive_parent);
+		CREATE INDEX address_cluster_text_idx ON address_cluster (_text);
+		CREATE INDEX network_cluster_text_idx ON network_cluster (address_text);
 		UPDATE address_cluster a SET orphan_adoptive_parent=n.address FROM network_cluster n WHERE (a._text=n.address_text AND ST_Intersects(n.buffer, a.geom) AND a.id NOT IN (SELECT address FROM network_cluster WHERE address IS NOT NULL)) OR (a.id=n.address);
 		CREATE TEMPORARY TABLE orphan_groups ON COMMIT DROP AS SELECT orphan_adoptive_parent, ST_CollectionExtract(ST_Collect(geom),1) AS geom FROM address_cluster GROUP BY orphan_adoptive_parent;
 		UPDATE address_cluster a SET geom=o.geom FROM orphan_groups o WHERE o.orphan_adoptive_parent=a.id;

--- a/lib/map.js
+++ b/lib/map.js
@@ -97,7 +97,7 @@ module.exports = function(argv, cb) {
     const output = fs.createWriteStream(path.resolve(__dirname, '..', argv.output));
 
     const poolConf = {
-        max: 10,
+        max: process.env.CI ? 10 : CPUS,
         user: 'postgres',
         database: argv.db,
         idleTimeoutMillis: 30000


### PR DESCRIPTION
Adds an index, which speeds up adoption approximately 60x in my testing. Parallelization hasn't been pursued yet but could be.

I also bumped the postgres client pool size to the number of CPUs on the system -- in practice this will go unused, but was early work to support parallelization. Won't hurt to merge.

cc @ingalls