### PR TITLE
[ready] remove low-quality network_cluster => address_cluster matches

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -75,14 +75,15 @@ class Cluster {
     adoption(cb) {
         this.pool.query(`
                 BEGIN;
-		ALTER TABLE network_cluster ADD COLUMN IF NOT EXISTS address_text TEXT;
-		UPDATE network_cluster n SET address_text=a._text FROM address_cluster a WHERE n.address = a.id;
-		ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT;
-		UPDATE address_cluster a SET orphan_adoptive_parent=n.address FROM network_cluster n WHERE (a._text=n.address_text AND ST_Intersects(n.buffer, a.geom) AND a.id NOT IN (SELECT address FROM network_cluster WHERE address IS NOT NULL)) OR (a.id=n.address);
-		CREATE TEMPORARY TABLE orphan_groups ON COMMIT DROP AS SELECT orphan_adoptive_parent, ST_CollectionExtract(ST_Collect(geom),1) AS geom FROM address_cluster GROUP BY orphan_adoptive_parent;
-		UPDATE address_cluster a SET geom=o.geom FROM orphan_groups o WHERE o.orphan_adoptive_parent=a.id;
-		DELETE FROM address_cluster WHERE id NOT IN (SELECT orphan_adoptive_parent FROM address_cluster WHERE orphan_adoptive_parent IS NOT NULL);
-		ALTER TABLE address_cluster DROP COLUMN orphan_adoptive_parent;
+                ALTER TABLE network_cluster DROP COLUMN IF EXISTS address_text;
+                ALTER TABLE network_cluster ADD COLUMN address_text TEXT;
+                UPDATE network_cluster n SET address_text=a._text FROM address_cluster a WHERE n.address = a.id;
+                ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT;
+                UPDATE address_cluster a SET orphan_adoptive_parent=n.address FROM network_cluster n WHERE (a._text=n.address_text AND ST_Intersects(n.buffer, a.geom) AND a.id NOT IN (SELECT address FROM network_cluster WHERE address IS NOT NULL)) OR (a.id=n.address);
+                CREATE TEMPORARY TABLE orphan_groups ON COMMIT DROP AS SELECT orphan_adoptive_parent, ST_CollectionExtract(ST_Collect(geom),1) AS geom FROM address_cluster GROUP BY orphan_adoptive_parent;
+                UPDATE address_cluster a SET geom=o.geom FROM orphan_groups o WHERE o.orphan_adoptive_parent=a.id;
+                DELETE FROM address_cluster WHERE id NOT IN (SELECT orphan_adoptive_parent FROM address_cluster WHERE orphan_adoptive_parent IS NOT NULL);
+                ALTER TABLE address_cluster DROP COLUMN orphan_adoptive_parent;
                 COMMIT;
         `, (err, res) => {
             return cb(err);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,7 +1,8 @@
 const buffer = require('./buffer');
-const linker = require('./linker');
-
+const dist = require('fast-levenshtein').get;
+const Cursor = require('pg-cursor');
 const turf = require('@turf/turf');
+const Queue = require('d3-queue').queue;
 const _ = require('lodash');
 const wk = require('wellknown');
 
@@ -67,10 +68,14 @@ class Cluster {
         });
     }
 
+
+    /**
+    * Expands address_clusters with identically-named but unmatched nearby address clusters
+    **/
     adoption(cb) {
         this.pool.query(`
                 BEGIN;
-		ALTER TABLE network_cluster ADD COLUMN address_text TEXT;
+		ALTER TABLE network_cluster ADD COLUMN IF NOT EXISTS address_text TEXT;
 		UPDATE network_cluster n SET address_text=a._text FROM address_cluster a WHERE n.address = a.id;
 		ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT;
 		UPDATE address_cluster a SET orphan_adoptive_parent=n.address FROM network_cluster n WHERE (a._text=n.address_text AND ST_Intersects(n.buffer, a.geom) AND a.id NOT IN (SELECT address FROM network_cluster WHERE address IS NOT NULL)) OR (a.id=n.address);
@@ -82,6 +87,74 @@ class Cluster {
         `, (err, res) => {
             return cb(err);
         });
+    }
+
+    /**
+    * Prune network_cluster assignments where the address_cluster is assigned to more than one
+    **/
+    prune(cb) {
+	let that = this;
+	this.pool.connect((err, client, pg_done) => {
+            if (err) return cb(err);
+	    const cursor = client.query(new Cursor(`
+		SELECT
+		    a.id AS address_id,
+		    a.text AS address_text,
+		    a.text_tokenless AS address_text_tokenless,
+		    n.id AS network_id,
+		    n.text AS network_text,
+		    n.text_tokenless AS network_text_tokenless
+		FROM network_cluster n inner join address_cluster a ON n.address=a.id
+		WHERE n.address IN
+		    (SELECT address FROM network_cluster WHERE address IS NOT NULL GROUP BY address HAVING COUNT(address) > 1)
+		ORDER BY a.id ASC;
+	    `));
+
+	    function pruneBatch(batch, cb2) {
+		let bestMatch = null;
+		for (let batchi = 0; batchi < batch.length; batchi++) {
+		    let cur = batch[batchi];
+		    let curDist = (0.25 * dist(cur.address_text, cur.network_text)) + (0.75 * dist(cur.address_text_tokenless, cur.network_text_tokenless));    
+		    if (!bestMatch || (curDist < bestMatch[0]))
+			bestMatch = [curDist, cur.network_id];
+		}
+		// return a list of all network_ids that are not the best match
+		return cb2(null, batch.map((x) => { return x.network_id; }).filter((x) => { return x !== bestMatch[1]; }));
+	    }
+
+	    let batch = [];
+	    let q = Queue();
+
+	    iterate();
+
+	    function iterate() {
+		cursor.read(100, (err, rows) => {
+		    if (!rows.length) {
+			if (batch.length)
+			    q.defer(pruneBatch, batch);
+			q.awaitAll((err, results) => {
+			    let deleteMe = results.reduce((prev, cur) => { return prev.concat(cur); }, []).join(',');
+			    that.pool.query(`UPDATE network_cluster SET address=NULL WHERE id IN (${deleteMe});`, (err, res) => {
+				if (err) return cb(err);
+				pg_done();
+				return cb();
+			    });
+			});
+		    }
+		    else {
+			rows.forEach((row) => {
+			    if ((batch.length > 0) && (batch[batch.length - 1].address_id !== row.address_id)) {
+				q.defer(pruneBatch, batch.slice(0));
+				batch = [];
+			    }
+			    batch.push(row);
+			});
+
+			return iterate();
+		    }
+		});
+	    }
+	});
     }
 
     optimize(cb) {

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -7,6 +7,8 @@ const diacritics = require('diacritics').remove
 module.exports = (street, addresses) => {
     let current;
 
+    console.error('STREET', street.text);
+
     for (let addr_it = 0; addr_it < addresses.length; addr_it++) {
         let address = addresses[addr_it];
 
@@ -45,6 +47,8 @@ module.exports = (street, addresses) => {
         let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)
 
         if (!current || current.score < score) {
+	    console.error('NEW WINNER', street._text, score, address);
+
             current = {
                 score: score,
                 address: address

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -16,7 +16,7 @@ module.exports = (street, addresses) => {
 	// don't bother considering if the tokenless forms don't share a starting letter
 	// this might require adjustment for countries with addresses that have leading tokens which aren't properly stripped
 	// from the token list
-	if (address.text_tokenless[0] !== street.text_tokenless[0])
+	if (address.text_tokenless && street.text_tokenless && (address.text_tokenless[0] !== street.text_tokenless[0]))
 	    continue;
 
         // use a weighted average w/ the tokenless dist score if possible

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -7,14 +7,17 @@ const diacritics = require('diacritics').remove
 module.exports = (street, addresses) => {
     let current;
 
-    console.error('STREET', street.text);
-
     for (let addr_it = 0; addr_it < addresses.length; addr_it++) {
         let address = addresses[addr_it];
 
-        //Short Circuit if the text is exactly the same
-
+        // Short Circuit if the text is exactly the same
         if (address.text === street.text) return address;
+
+	// don't bother considering if the tokenless forms don't share a starting letter
+	// this might require adjustment for countries with addresses that have leading tokens which aren't properly stripped
+	// from the token list
+	if (address.text_tokenless[0] !== street.text_tokenless[0])
+	    continue;
 
         // use a weighted average w/ the tokenless dist score if possible
         let levScore;
@@ -47,8 +50,6 @@ module.exports = (street, addresses) => {
         let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)
 
         if (!current || current.score < score) {
-	    console.error('NEW WINNER', street._text, score, address);
-
             current = {
                 score: score,
                 address: address

--- a/lib/map.js
+++ b/lib/map.js
@@ -421,7 +421,10 @@ module.exports = function(argv, cb) {
                         if (!rows.length) {
                             pg_done();
                             console.error('ok - addresses assigned to linestring');
-                            return cluster.adoption(finalize);
+                            return cluster.adoption(() => {
+				console.error('ok - adopted stranded address clusters into stable homes');
+				cluster.prune(finalize);
+			    });
                         }
 
                         rows.forEach((row) => {
@@ -476,7 +479,7 @@ module.exports = function(argv, cb) {
         if (err)
         return cb(err);
 
-        console.error('ok - adopted stranded address clusters into stable homes');
+	console.error('ok - pruned multiple network_clusters matched to the same address_cluster');
 
         if (argv['error-network']) argv['error-network'].close();
         if (argv['error-address']) argv['error-address'].close();

--- a/lib/match.js
+++ b/lib/match.js
@@ -67,7 +67,6 @@ function match(id, cb) {
             text_tokenless: res.rows[0].network_text_tokenless
         }, res.rows)
 
-
         if (!address) return cb();
 
         pool.query(`

--- a/lib/match.js
+++ b/lib/match.js
@@ -41,6 +41,7 @@ function init(opts) {
 }
 
 function match(id, cb) {
+    console.error('in match', id);
     pool.query(`
         SELECT
             network.text AS network,
@@ -66,6 +67,7 @@ function match(id, cb) {
             _text: res.rows[0].network_text,
             text_tokenless: res.rows[0].network_text_tokenless
         }, res.rows)
+
 
         if (!address) return cb();
 

--- a/lib/match.js
+++ b/lib/match.js
@@ -41,7 +41,6 @@ function init(opts) {
 }
 
 function match(id, cb) {
-    console.error('in match', id);
     pool.query(`
         SELECT
             network.text AS network,

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -250,6 +250,72 @@ test('cluster.network', (t) => {
     });
 });
 
+test('cluster.adoption', (t) => {
+    const popQ = Queue(1);
+
+    //CREATE pt2itp TABLES
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+            CREATE TABLE network_cluster (address BIGINT, geom GEOMETRY(LINESTRING, 4326), buffer GEOMETRY(GEOMETRY, 4326));
+            CREATE TABLE address_cluster (id BIGINT, _text TEXT, geom GEOMETRY(GEOMETRY, 4326));
+            COMMIT;
+        `, (err, res) => {
+            t.error(err);
+            return done();
+        });
+    });
+
+    //POPULATE NETWORK
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+            INSERT INTO network_cluster (address, geom) VALUES (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"LineString","coordinates":[[-77.06428527832031,38.87018642754998],[-77.08488464355469,38.84131208727261],[-77.1240234375,38.826870521380634],[-77.13844299316406,38.817241182948266],[-77.16316223144531,38.80440003947544],[-77.178955078125,38.788880569497124],[-77.18513488769531,38.76853959726423],[-77.18719482421874,38.74337300148123],[-77.22633361816405,38.710160941206645]]}'), 4326));
+            UPDATE network_cluster SET buffer=ST_Buffer(ST_Envelope(geom), 0.01);
+            INSERT INTO address_cluster (id, _text, geom) VALUES (1, 'Pollard St', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"MultiPoint","coordinates":[[-77.06468224525452,38.87007783654626],[-77.06486463546752,38.86984394766712],[-77.06496119499207,38.86961005801844]]}'), 4326));
+            INSERT INTO address_cluster (id, _text, geom) VALUES (2, 'Pollard St', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"MultiPoint","coordinates":[[-77.22588300704956,38.710068850025856],[-77.22571134567261,38.710269776085525],[-77.22553968429565,38.710504189108065]]}'), 4326));
+            COMMIT;
+        `, (err, res) => {
+            t.error(err);
+            return done();
+        });
+    });
+
+    popQ.defer((done) => {
+        cluster.adoption((err) => {
+            t.error(err);
+            return done();
+        });
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            SELECT id, _text, ST_NPoints(geom) AS npoints FROM address_cluster;
+        `, (err, res) => {
+            t.error(err);
+
+            t.equals(res.rows.length, 1);
+            t.deepEquals(res.rows[0], { id: '1', _text: 'Pollard St', npoints: 6 });
+            return done();
+        });
+    });
+
+    popQ.await((err) => {
+        t.error(err);
+
+        pool.query(`
+            BEGIN;
+            DROP TABLE address_cluster;
+            DROP TABLE network_cluster;
+            COMMIT;
+        `, (err, res) => {
+            t.error(err);
+            t.end();
+        });
+    });
+});
+
+
 test('cluster.prune', (t) => {
     const popQ = Queue(1);
 

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -250,15 +250,15 @@ test('cluster.network', (t) => {
     });
 });
 
-test('cluster.adoption', (t) => {
+test('cluster.prune', (t) => {
     const popQ = Queue(1);
 
     //CREATE pt2itp TABLES
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            CREATE TABLE network_cluster (address BIGINT, geom GEOMETRY(LINESTRING, 4326), buffer GEOMETRY(GEOMETRY, 4326));
-            CREATE TABLE address_cluster (id BIGINT, _text TEXT, geom GEOMETRY(GEOMETRY, 4326));
+            CREATE TABLE network_cluster (id BIGINT, address BIGINT, text TEXT, text_tokenless TEXT);
+            CREATE TABLE address_cluster (id BIGINT, text TEXT, text_tokenless TEXT);
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -270,10 +270,16 @@ test('cluster.adoption', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO network_cluster (address, geom) VALUES (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"LineString","coordinates":[[-77.06428527832031,38.87018642754998],[-77.08488464355469,38.84131208727261],[-77.1240234375,38.826870521380634],[-77.13844299316406,38.817241182948266],[-77.16316223144531,38.80440003947544],[-77.178955078125,38.788880569497124],[-77.18513488769531,38.76853959726423],[-77.18719482421874,38.74337300148123],[-77.22633361816405,38.710160941206645]]}'), 4326));
-            UPDATE network_cluster SET buffer=ST_Buffer(ST_Envelope(geom), 0.01);
-            INSERT INTO address_cluster (id, _text, geom) VALUES (1, 'Pollard St', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"MultiPoint","coordinates":[[-77.06468224525452,38.87007783654626],[-77.06486463546752,38.86984394766712],[-77.06496119499207,38.86961005801844]]}'), 4326));
-            INSERT INTO address_cluster (id, _text, geom) VALUES (2, 'Pollard St', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"MultiPoint","coordinates":[[-77.22588300704956,38.710068850025856],[-77.22571134567261,38.710269776085525],[-77.22553968429565,38.710504189108065]]}'), 4326));
+	    INSERT INTO address_cluster (id, text, text_tokenless) VALUES (1, 'Main St', 'Main');
+	    INSERT INTO network_cluster (id, address, text, text_tokenless) VALUES (1, 1, 'Main St', 'Main');
+	    INSERT INTO network_cluster (id, address, text, text_tokenless) VALUES (2, 1, 'Moin St', 'Main');
+
+	    INSERT INTO address_cluster (id, text, text_tokenless) VALUES (2, 'Pollard Rd', 'Pollard');
+	    INSERT INTO network_cluster (id, address, text, text_tokenless) VALUES (3, 2, 'Pollard St', 'Pollard');
+
+	    INSERT INTO address_cluster (id, text, text_tokenless) VALUES (3, 'First St', 'First');
+	    INSERT INTO network_cluster (id, address, text, text_tokenless) VALUES (4, 3, 'First St', 'First');
+	    INSERT INTO network_cluster (id, address, text, text_tokenless) VALUES (5, 3, 'Second St', 'Second');
             COMMIT;
         `, (err, res) => {
             t.error(err);
@@ -282,7 +288,7 @@ test('cluster.adoption', (t) => {
     });
 
     popQ.defer((done) => {
-        cluster.adoption((err) => {
+        cluster.prune((err) => {
             t.error(err);
             return done();
         });
@@ -290,12 +296,30 @@ test('cluster.adoption', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, _text, ST_NPoints(geom) AS npoints FROM address_cluster;
+            SELECT * FROM address_cluster ORDER BY id ASC;
         `, (err, res) => {
             t.error(err);
+	    if (process.env.UPDATE) {
+		fs.writeFileSync(__dirname + '/fixtures/cluster.prune-address.expected.json', JSON.stringify(res.rows, null, 2))
+		t.fail();
+	    }
+	    else
+		t.deepEquals(res.rows, require(__dirname + '/fixtures/cluster.prune-address.expected.json'));
+            return done();
+        });
+    });
 
-            t.equals(res.rows.length, 1);
-            t.deepEquals(res.rows[0], { id: '1', _text: 'Pollard St', npoints: 6 });
+    popQ.defer((done) => {
+        pool.query(`
+            SELECT * FROM network_cluster ORDER BY id ASC;
+        `, (err, res) => {
+            t.error(err);
+	    if (process.env.UPDATE) {
+		fs.writeFileSync(__dirname + '/fixtures/cluster.prune-network.expected.json', JSON.stringify(res.rows, null, 2))
+		t.fail();
+	    }
+	    else
+		t.deepEquals(res.rows, require(__dirname + '/fixtures/cluster.prune-network.expected.json'));
             return done();
         });
     });

--- a/test/fixtures/cluster.prune-address.expected.json
+++ b/test/fixtures/cluster.prune-address.expected.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "1",
+    "text": "Main St",
+    "text_tokenless": "Main"
+  },
+  {
+    "id": "2",
+    "text": "Pollard Rd",
+    "text_tokenless": "Pollard"
+  },
+  {
+    "id": "3",
+    "text": "First St",
+    "text_tokenless": "First"
+  }
+]

--- a/test/fixtures/cluster.prune-network.expected.json
+++ b/test/fixtures/cluster.prune-network.expected.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "1",
+    "address": "1",
+    "text": "Main St",
+    "text_tokenless": "Main"
+  },
+  {
+    "id": "2",
+    "address": null,
+    "text": "Moin St",
+    "text_tokenless": "Main"
+  },
+  {
+    "id": "3",
+    "address": "2",
+    "text": "Pollard St",
+    "text_tokenless": "Pollard"
+  },
+  {
+    "id": "4",
+    "address": "3",
+    "text": "First St",
+    "text_tokenless": "First"
+  },
+  {
+    "id": "5",
+    "address": null,
+    "text": "Second St",
+    "text_tokenless": "Second"
+  }
+]


### PR DESCRIPTION
This PR addresses two error conditions that are possible in master:

- low-quality linker matches where the winning `address_cluster` doesn't share a leading letter with the winning `network_cluster` (per @apendleton & @boblannon's suggestions)
- cases where a given `address_cluster` is assigned to multiple `network_cluster`s. A postprocessing step is added that reviews all such network/address groups and removes all but the best text matches.