### PR TITLE
123 1/2 Style Addresses

### DIFF
--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -26,6 +26,8 @@ function map(feat) {
 
     //Transform addresses that are almost supported to a supported type
 
+    feat.properties.number = feat.properties.number.replace(/\s1\/2$/, '');
+
     //123 B => 123B
     if (/^\d+\s[a-z]$/.test(feat.properties.number)) {
         feat.properties.number = feat.properties.number.replace(/\s/g, '');

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -155,6 +155,22 @@ test('Strip-Unit', (t) => {
     t.deepEquals(map({
         type: 'Feature',
         properties: {
+            number: '123 1/2',
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }), {
+        geometry: { coordinates: [ 0, 0 ], type: 'Point' },
+        properties: { number: '123', street: 'Main St' },
+        type: 'Feature'
+    }, 'Stripped 123 1/2 Address');
+
+    t.deepEquals(map({
+        type: 'Feature',
+        properties: {
             number: '123-45',
             street: 'Main St'
         },


### PR DESCRIPTION
We currently toss address of the form `123 1/2`

- :rocket: :white_check_mark: Remove the `1/2` from numbers - numbers are deduped if they already exist in the non-`1/2` form.