### PR TITLE
bugfixes - CPU count, duplicate coords

### DIFF
--- a/lib/explode.js
+++ b/lib/explode.js
@@ -93,7 +93,9 @@ function main(streets, settings = {}) {
                         working = streets.features[feat_it].geometry.coordinates.splice(0,1)[0];
 
                         if (streets.features[feat_it].geometry.coordinates.length === 0) {
-                            results.features.push(turf.lineString(dedup(working), streets.features[feat_it].properties));
+                            let dedupedWorking = dedup(working);
+                            if (dedupedWorking.length > 1)
+                                results.features.push(turf.lineString(dedup(working), streets.features[feat_it].properties));
                         } else {
                             line_it = -1;
                         }

--- a/lib/map.js
+++ b/lib/map.js
@@ -94,7 +94,7 @@ module.exports = function(argv, cb) {
     const output = fs.createWriteStream(path.resolve(__dirname, '..', argv.output));
 
     const poolConf = {
-        max: process.env.CI ? 10 : CPUS,
+        max: process.env.CI ? 10 : Math.min(16, CPUS),
         user: 'postgres',
         database: argv.db,
         idleTimeoutMillis: 30000
@@ -332,7 +332,7 @@ module.exports = function(argv, cb) {
 
                 bar.tick(1); //Show progress bar
 
-                let cpu_spawn = Math.min(Math.ceil(res.rows.length / 1000), CPUS); //number of 1000 groups or # of CPUs, whichever is smaller
+                let cpu_spawn = Math.min(Math.ceil(res.rows.length / 1000), Math.min(16, CPUS)); //number of 1000 groups or # of CPUs, whichever is smaller
                 let nursery = [];
 
                 let ids = res.rows.map((row) => { return row.id });
@@ -354,22 +354,28 @@ module.exports = function(argv, cb) {
                     child.stderr.pipe(process.stderr);
 
                     child.on('message', (message) => {
-                        if (message.error) return cb(err);
+                        if (message.error) { return cb(new Error(`splitter child process error (${message.id}, jobs ${message.jobs}: ${message.error})`)); }
 
                         if (message.jobs) bar.tick(message.jobs);
 
                         if (!ids.length) {
-                            nursery[message.id].active = false;
-                            nursery[message.id].child.kill();
+                            if (message.type === 'end') {
+                                // type == end means we have received the all-clear from a process that acted on a kill signal
+                                nursery[message.id].active = false;
+                                nursery[message.id].child.kill();
 
-                            let active = nursery.filter((instance) => {
-                                if (instance.active) return true;
-                                else return false;
-                            });
+                                let active = nursery.filter((instance) => {
+                                    if (instance.active) return true;
+                                    else return false;
+                                });
 
-                            if (!active.length) {
-                                pg_done();
-                                return orphanAddr();
+                                if (!active.length) {
+                                    pg_done();
+                                    return orphanAddr();
+                                }
+                            } else {
+                                // send kill signal so the pgpool can be shut down properly
+                                nursery[message.id].child.send({ id: message.id, type: 'end' });
                             }
                         } else {
                             nursery[message.id].child.send(ids.splice(0, 1000));

--- a/lib/split.js
+++ b/lib/split.js
@@ -28,10 +28,15 @@ process.on('message', (message) => {
             });
         });
     } else {
-        init(message);
-        id = message.id;
+        if (message.type && (message.type === 'end')) {
+            kill();
+        } else {
+            init(message);
+            id = message.id;
+        }
 
         process.send({
+            type: message.type || false,
             id: id,
             jobs: 0
         });

--- a/test/explode.test.js
+++ b/test/explode.test.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-
+// add test for feature that dedupe will collapse & should discard
 const explode = require('../lib/explode');
 
 test('explode', (t) => {
@@ -244,6 +244,24 @@ test('explode', (t) => {
     });
     t.deepEquals(res.features.length, 3);
 
+    t.end();
+});
+
+test('explode#dedupeBorks', (t) => {
+    t.deepEquals(explode({
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "MultiLineString",
+                "coordinates": [ 
+                    [ [0,1], [1,0] ],
+                    [ [1,1], [1,1] ]
+                ]
+            }
+        }]
+    }, { noDistance: true }).features[0].geometry.coordinates, [[0,1], [1,0]], 'single-point dedupes are discarded');
     t.end();
 });
 


### PR DESCRIPTION
Two bugs became apparent in `split.js` as I attempted to process Italian address points from OpenAddresses:

- a call to `turf.linestring` failed when passed a one-coordinate feature. This was the result of a call to `dedup()` which was being passed a two-point line of coordinates that had been truncated enough to be identical. `dedup` removed one of them, producing the error. This case is now detected and handled.
- `split.js` was producing weird errors related to `proc.c` and `InitProcess`. This looked like postgres connection exhaustion. Initially I implemented a system for calling the postgres pool shutdown function. That code remains in place (it's good hygiene!) but was not the issue: instead, the split.js parallelism based on CPU count was the culprit, as each child process instantiated its own postgres connection pool and I was on a 64 core ECS container. Capping the total number of child processes to 16 is inelegant but seems to do the trick. 