### PR TITLE
handle multi-char separators better in titlecase.js

### DIFF
--- a/lib/label/titlecase.js
+++ b/lib/label/titlecase.js
@@ -1,6 +1,7 @@
 /*eslint no-lonely-if: "off"*/ // <-- complying with this linting rule would reduce code readability
 
 const wordBoundary = new RegExp("[\\s\\u2000-\\u206F\\u2E00-\\u2E7F\\\\!\"#$%&()*+,\\-.\\/:;<=>?@\\[\\]^_{|}~]+", 'g');
+const allowedAfterSpace = new RegExp("[()#<>\\[\\]{}\"]+");
 const diacritics = require('diacritics').remove;
 const dist = require('fast-levenshtein').get
 
@@ -24,8 +25,22 @@ function numCaseChanges(x) {
 function titleCase(text, minors) {
     minors = minors || [];
     let separators = [];
-    for (let separator = wordBoundary.exec(text); !!separator; separator = wordBoundary.exec(text))
-        separators.push(separator[0][0]);
+    for (let separator = wordBoundary.exec(text); !!separator; separator = wordBoundary.exec(text)) {
+        // preserve the characters separating words, collapsing runs of whitespace but preserving other stuff
+        let sep = '';
+        for (let sep_i = 0; sep_i < separator[0].length; sep_i++) {
+            let lastCharIsSpace = (sep_i > 0) && (sep[sep.length - 1] === ' ');
+            if (!(/\s/.test(separator[0][sep_i]))) {
+                // don't add separators at the beginning of words (after spaces)
+                if (!lastCharIsSpace || allowedAfterSpace.test(separator[0][sep_i]))
+                    sep += separator[0][sep_i];
+            }
+            else if (!lastCharIsSpace) {
+                sep += ' ';
+            }
+        }
+        separators.push(sep);
+    }
     return text
         .split(wordBoundary)
         .map((y) => { return y.toLowerCase(); })

--- a/test/titlecase.test.js
+++ b/test/titlecase.test.js
@@ -14,7 +14,9 @@ tape('title case xformation', (t) => {
         ['abra CAda -bra', 'Abra Cada Bra'],
         ['our lady of whatever', 'Our Lady of Whatever'],
         ['our lady OF whatever', 'Our Lady of Whatever'],
-        ['St Martin\'s Neck Road', 'St Martin\'s Neck Road']
+        ['St Martin\'s Neck Road', 'St Martin\'s Neck Road'],
+        ['MT. MOOSILAUKE HWY', 'Mt. Moosilauke Hwy'],
+        ['some  miscellaneous rd (what happens to parentheses?)', 'Some Miscellaneous Rd (What Happens to Parentheses?)']
     ];
 
     for (let test of tests)


### PR DESCRIPTION
My code did a bad job on things like `MT. LAKE RD` -- cf https://github.com/mapbox/mapbox-places-address/pull/62#issuecomment-321372459

This PR adjusts the titlecase behavior to fold together separators a little more conservatively.

cc @ingalls @aaaandrea 