### PR TITLE
don't attempt to geocode house numbers that are duplicates

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -31,7 +31,8 @@ function test(argv, cb) {
                 'output',
                 'config',
                 'limit',
-                'name'
+                'name',
+                'dupes'
             ],
             alias: {
                 database: 'db',
@@ -70,6 +71,8 @@ function test(argv, cb) {
     }
 
     if (argv.limit) argv.limit = parseInt(argv.limit);
+    argv.dupes = !!argv.dupes;
+    let dupeCount = 0;
 
     const pool = new pg.Pool({
         max: 10,
@@ -135,10 +138,25 @@ function test(argv, cb) {
 
                             let addrQ = Queue(25);
 
+
                             for (let row of rows) {
                                 row.geom = JSON.parse(row.geom);
 
-                                for (let addr of row.geom.coordinates) {
+                                // by default, don't query for address numbers that appear >1x in a single address cluster
+                                let coords = row.geom.coordinates;
+                                if (!argv.dupes) {
+                                    let foundNumbers = {};
+                                    coords = row.geom.coordinates.filter((coord) => {
+                                        if (foundNumbers[coord[2]]) {
+                                            dupeCount++;
+                                            return false;
+                                        }
+                                        foundNumbers[coord[2]] = true;
+                                        return true;
+                                    });
+                                }
+
+                                for (let addr of coords) {
                                     if (addr[2] % 1 != 0 && meta.units) {
                                         let unit = parseInt(String(addr[2]).split('.')[1]);
                                         let num = String(addr[2]).split('.')[0];
@@ -295,6 +313,8 @@ function test(argv, cb) {
                                 }
                                 console.error();
                                 console.error(`ok - ${stats.fail}/${stats.total} failed to geocode`);
+                                if (!argv.dupes)
+                                    console.error(`ok - skipped ${dupeCount} entries as duplicate house numbers`);
                                 return cb();
                             }
 


### PR DESCRIPTION
A large portion of `DIST FAIL`s that I'm seeing are due to the same house number existing twice within an address cluster. I'm of two minds about this: we should definitely be aware of when the underlying data looks this way. At the same time, geocoding these is fairly pointless.

This PR adds a new overridable default behavior by which duplicate addresses are skipped and the total count is reported at the end of test mode. Some empirical results:

## before
```
ERROR TYPE                   COUNT
------------------------------------------
DIST                          3169 (12.6%)
NAME MISMATCH                21929 (86.9%)
TEXT                           125 (0.5%)
```

## after
```
ERROR TYPE                   COUNT
------------------------------------------
DIST                           710 (3.1%)
NAME MISMATCH                22328 (96.7%)
TEXT                            62 (0.3%)
```

cc @ingalls @aaaandrea 