### PR TITLE
fix bug in duplicate avoidance code

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -146,14 +146,14 @@ function test(argv, cb) {
                                 let coords = row.geom.coordinates;
                                 if (!argv.dupes) {
                                     let foundNumbers = row.geom.coordinates.reduce((prev, cur) => {
-					if (!prev[cur[2]]) prev[cur[2]] = 0;
-					prev[cur[2]] += 1;
-					return prev;
-				    }, {});
+                                        if (!prev[cur[2]]) prev[cur[2]] = 0;
+                                        prev[cur[2]] += 1;
+                                        return prev;
+                                    }, {});
                                     coords = row.geom.coordinates.filter((coord) => {
-					return foundNumbers[coord[2]] === 1;
-				    });
-				    dupeCount += row.geom.coordinates.length - coords.length;
+                                        return foundNumbers[coord[2]] === 1;
+                                    });
+                                    dupeCount += row.geom.coordinates.length - coords.length;
                                 }
 
                                 for (let addr of coords) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -145,15 +145,15 @@ function test(argv, cb) {
                                 // by default, don't query for address numbers that appear >1x in a single address cluster
                                 let coords = row.geom.coordinates;
                                 if (!argv.dupes) {
-                                    let foundNumbers = {};
+                                    let foundNumbers = row.geom.coordinates.reduce((prev, cur) => {
+					if (!prev[cur[2]]) prev[cur[2]] = 0;
+					prev[cur[2]] += 1;
+					return prev;
+				    }, {});
                                     coords = row.geom.coordinates.filter((coord) => {
-                                        if (foundNumbers[coord[2]]) {
-                                            dupeCount++;
-                                            return false;
-                                        }
-                                        foundNumbers[coord[2]] = true;
-                                        return true;
-                                    });
+					return foundNumbers[coord[2]] === 1;
+				    });
+				    dupeCount += row.geom.coordinates.length - coords.length;
                                 }
 
                                 for (let addr of coords) {


### PR DESCRIPTION
Previously the code only omitted the 2...nth occurrences of duplicate points. But of course this would still result in ambiguous geocodes.