### PR TITLE
don't pick match winners arbitrarily

### DIFF
--- a/lib/linker.js
+++ b/lib/linker.js
@@ -5,13 +5,14 @@ const diacritics = require('diacritics').remove
  * Generates a map of street => address
  */
 module.exports = (street, addresses) => {
-    let current;
+    let maxScore = false;
 
     for (let addr_it = 0; addr_it < addresses.length; addr_it++) {
         let address = addresses[addr_it];
 
         // Short Circuit if the text is exactly the same
-        if (address.text === street.text) return address;
+        if (address.text === street.text)
+            return addresses.filter((a) => { return a.text === street.text; });
 
         // don't bother considering if the tokenless forms don't share a starting letter
         // this might require adjustment for countries with addresses that have leading tokens which aren't properly stripped
@@ -38,26 +39,28 @@ module.exports = (street, addresses) => {
                     longer = diacritics(address._text).toLowerCase();
                 }
                 if (longer.indexOf(shorter) !== -1)
-                    return address;
+                    return addresses.filter((a) => { return a._text === address._text; });
             }
 
+            if (!street.text || !street.text.length || !address.text || !address.text.length)
+                continue;
 
-            if (!street.text || !street.text.length || !address.text || !address.text.length) continue;
             levScore = dist(street.text, address.text);
         }
 
         //Calculate % Match
-        let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100)
+        let score = 100 - (((2 * levScore) / (address.text.length + street.text.length)) * 100);
 
-        if (!current || current.score < score) {
-            current = {
-                score: score,
-                address: address
-            };
-        }
+        addresses[addr_it].score = score;
+
+        if (!maxScore || (score > maxScore))
+            maxScore = score;
     }
 
-    //There is a potential address match and it has a lev. distance of over 40% the same
-    if (current && current.address && current.score > 40)  return current.address;
-    return false;
+    // score must be > 40% for us to return any matches
+    let qualifyingAddresses = addresses.filter((a) => { return a.score === maxScore; });
+    if ((qualifyingAddresses.length > 0) && (maxScore > 40))
+        return qualifyingAddresses;
+    else
+        return false;
 }

--- a/lib/match.js
+++ b/lib/match.js
@@ -84,16 +84,17 @@ function match(id, cb) {
                     SELECT
                         acd.id
                     FROM
-                        (SELECT ac.id, (ST_Dump(ac.geom)).geom FROM address_cluster ac WHERE id IN (${addressIds})) acd
+                        (SELECT ac.id, (ST_Dump(ac.geom)).geom FROM address_cluster ac WHERE ac.id IN (${addressIds})) acd
                     WHERE
                         ST_Intersects(
-                            geom,
-                            (SELECT buffer FROM network_cluster WHERE id=${id})
+                            acd.geom,
+                            (SELECT buffer FROM network_cluster nc WHERE nc.id=${id})
                         )
                     GROUP BY acd.id
                     ORDER BY COUNT(acd.id) DESC
                     LIMIT 1
-                );
+                )
+                WHERE network_cluster.id = ${id};
             `, (err, res) => {
                 return cb(err);
             });

--- a/lib/match.js
+++ b/lib/match.js
@@ -66,15 +66,36 @@ function match(id, cb) {
             text_tokenless: res.rows[0].network_text_tokenless
         }, res.rows)
 
-        if (!address) return cb();
+        if (!address || address.length === 0) return cb();
 
-        pool.query(`
-            UPDATE network_cluster
-            SET address = ${address.id}
-            WHERE network_cluster.id = ${id};
-        `, (err, res) => {
-            return cb(err);
-        });
+        if (address.length === 1) {
+            pool.query(`
+                UPDATE network_cluster
+                SET address = ${address.id}
+                WHERE network_cluster.id = ${id};
+            `, (err, res) => {
+                return cb(err);
+            });
+        } else {
+            let addressIds = addresses.map((a) => { return id.toString(); }).join(',');
+            pool.query(`
+                UPDATE network_cluster
+                SET address = (
+                    SELECT
+                        acd.id AS cnt
+                    FROM
+                        (SELECT ac.id, (ST_Dump(ac.geom)).geom FROM address_cluster ac WHERE id IN (${address_ids})) acd
+                    WHERE
+                        ST_Intersects(
+                            geom,
+                            (SELECT buffer FROM network_cluster WHERE id=${id})
+                        )
+                    GROUP BY acd.id ORDER BY cnt LIMIT 1
+                );
+            `, (err, res) => {
+                return cb(err);
+            });
+        }
     });
 }
 

--- a/lib/match.js
+++ b/lib/match.js
@@ -71,27 +71,27 @@ function match(id, cb) {
         if (address.length === 1) {
             pool.query(`
                 UPDATE network_cluster
-                SET address = ${address.id}
+                SET address = ${address[0].id}
                 WHERE network_cluster.id = ${id};
             `, (err, res) => {
                 return cb(err);
             });
         } else {
-            let addressIds = addresses.map((a) => { return id.toString(); }).join(',');
+            let addressIds = address.map((a) => { return a.id.toString(); }).join(',');
             pool.query(`
                 UPDATE network_cluster
                 SET address = (
                     SELECT
-                        acd.id AS cnt
+                        acd.id
                     FROM
-                        (SELECT ac.id, (ST_Dump(ac.geom)).geom FROM address_cluster ac WHERE id IN (${address_ids})) acd
+                        (SELECT ac.id, (ST_Dump(ac.geom)).geom FROM address_cluster ac WHERE id IN (${addressIds})) acd
                     WHERE
                         ST_Intersects(
                             geom,
                             (SELECT buffer FROM network_cluster WHERE id=${id})
                         )
                     GROUP BY acd.id
-                    ORDER BY cnt DESC
+                    ORDER BY COUNT(acd.id) DESC
                     LIMIT 1
                 );
             `, (err, res) => {

--- a/lib/match.js
+++ b/lib/match.js
@@ -90,7 +90,9 @@ function match(id, cb) {
                             geom,
                             (SELECT buffer FROM network_cluster WHERE id=${id})
                         )
-                    GROUP BY acd.id ORDER BY cnt LIMIT 1
+                    GROUP BY acd.id
+                    ORDER BY cnt DESC
+                    LIMIT 1
                 );
             `, (err, res) => {
                 return cb(err);

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -6,14 +6,14 @@ test('Passing Linker Matches', (t) => {
         linker({ text: 'main st' }, [
             { id: 1, text: 'main st' }
         ]),
-        { id: 1, text: 'main st' },
+        [{ id: 1, text: 'main st' }],
     'basic match');
 
     t.deepEquals(
         linker({ text: 'main st' }, [
             { id: 1, text: 'maim st' },
         ]),
-        { id: 1, text: 'maim st' },
+        [{ id: 1, text: 'maim st', score: 85.71428571428572 }],
     'close match');
 
     t.deepEquals(
@@ -23,7 +23,7 @@ test('Passing Linker Matches', (t) => {
             { id: 3, text: 'main rd' },
             { id: 4, text: 'main dr' }
         ]),
-        { id: 1, text: 'main st' },
+        [{ id: 1, text: 'main st' }],
     'diff suff');
 
     t.deepEquals(
@@ -33,7 +33,7 @@ test('Passing Linker Matches', (t) => {
             { id: 3, text: 'asdg st' },
             { id: 4, text: 'maim st' }
         ]),
-        { id: 1, text: 'main st' },
+        [{ id: 1, text: 'main st' }],
     'diff name');
 
     t.deepEquals(
@@ -41,7 +41,7 @@ test('Passing Linker Matches', (t) => {
             { id: 1, text: 'ola', text_tokenless: 'ola'},
             { id: 2, text: 'ola avg', text_tokenless: 'ola avg'}
         ]),
-        { id: 1, text: 'ola', text_tokenless: 'ola'},
+        [{ id: 1, text: 'ola', text_tokenless: 'ola', score: 80}],
     'short names, tokens deweighted');
 
     t.deepEquals(
@@ -49,8 +49,32 @@ test('Passing Linker Matches', (t) => {
             { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
             { id: 2, text: 'avenida', text_tokenless: 'avenida'}
         ]),
-        { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
+        [{ id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'}],
     'all-token scenario (e.g. avenue street)');
+
+    t.deepEquals(
+        linker({ text: 'ave st', text_tokenless: '', _text: 'Avenue Street' }, [
+            { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
+            { id: 2, text: 'ave', text_tokenless: '', _text: 'Avenue'},
+            { id: 3, text: 'avenida', text_tokenless: 'avenida'}
+        ]),
+        [
+            { id: 1, text: 'ave', text_tokenless: '', _text: 'Avenue'},
+            { id: 2, text: 'ave', text_tokenless: '', _text: 'Avenue'}
+        ],
+    'multiple winners (exact match)');
+
+    t.deepEquals(
+        linker({ text: 'main st', text_tokenless: '', _text: 'Main Street' }, [
+            { id: 1, text: 'maim st', text_tokenless: 'maim', _text: 'Maim Street'},
+            { id: 2, text: 'maim st', text_tokenless: 'maim', _text: 'Maim Street'},
+            { id: 3, text: 'cross st', text_tokenless: 'cross', _text: 'Cross Street'}
+        ]),
+        [
+            { id: 1, text: 'maim st', score: 85.71428571428572, text_tokenless: 'maim', _text: 'Maim Street'},
+            { id: 2, text: 'maim st', score: 85.71428571428572, text_tokenless: 'maim', _text: 'Maim Street'}
+        ],
+    'multiple winners (score codepath)');
 
     t.end();
 });


### PR DESCRIPTION
`linker.js` is responsible for examining the set of address clusters that intersect a given network cluster's `buffer` box and selecting the one that has the closest matching name based on a heuristic that looks complex but is mostly about string distance (subject to a minimum match quality threshold). 

`linker` presently only returns zero or one matching features, but it is possible for the set of input addresses to contain multiple features that meet the matching heuristic identically well. In those circumstances the winner is determined by the vagaries of postgresql row ordering -- it's basically random. This leads to circumstances like https://github.com/ingalls/pt2itp/issues/154

This PR adjusts `linker`'s behavior to return all candidate addresses that score maximally on the matching heuristic. When this produces a single matching address, behavior is unchanged.

When more than one address is returned, an additional query is performed to determine which matching address cluster contains the most points falling within the network cluster's `buffer` box; this tiebreak mechanism determines the address cluster that is assigned to the network cluster.

cc @ingalls @aaaandrea 