### PR TITLE
discard fewer dupes in test mode

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -275,7 +275,14 @@ module.exports = function(argv, cb) {
                 let ids = res.rows.map((row) => { return row.id });
 
                 while (cpu_spawn--) {
-                    let child = CP.fork(path.resolve(__dirname, './match'));
+
+                    let child = CP.fork(path.resolve(__dirname, './match'), {
+                        stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+                    });
+
+                    child.stdin.on('error', epipe);
+                    child.stdout.on('error', epipe);
+                    child.stderr.on('error', epipe);
 
                     child.on('message', (message) => {
                         if (message.error) return cb(err);

--- a/lib/test.js
+++ b/lib/test.js
@@ -145,14 +145,30 @@ function test(argv, cb) {
                                 // by default, don't query for address numbers that appear >1x in a single address cluster
                                 let coords = row.geom.coordinates;
                                 if (!argv.dupes) {
-                                    let foundNumbers = row.geom.coordinates.reduce((prev, cur) => {
-                                        if (!prev[cur[2]]) prev[cur[2]] = 0;
-                                        prev[cur[2]] += 1;
+                                    let binnedCoords = row.geom.coordinates.reduce((prev, cur) => {
+                                        if (!prev[cur[2]]) prev[cur[2]] = [];
+                                        prev[cur[2]].push(cur);
                                         return prev;
                                     }, {});
-                                    coords = row.geom.coordinates.filter((coord) => {
-                                        return foundNumbers[coord[2]] === 1;
-                                    });
+				    coords = [];
+				    for(let zCoord in binnedCoords) {
+					let bin = binnedCoords[zCoord];
+					if (bin.length === 1) {
+					    coords = coords.concat(bin);
+					}
+					else {
+					    let allClose = true;
+					    for (let bi = 1; bi < bin.length; bi++) {
+						if (turf.distance(bin[0], bin[bi]) > 1) {
+						    allClose = false;
+						    break;
+						}
+					    }
+					    if (allClose)
+						coords = coords.concat(bin);
+					}
+				    }
+
                                     dupeCount += row.geom.coordinates.length - coords.length;
                                 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -151,7 +151,7 @@ function test(argv, cb) {
                                         return prev;
                                     }, {});
 				    coords = [];
-				    for(let zCoord in binnedCoords) {
+				    for (let zCoord in binnedCoords) {
 					let bin = binnedCoords[zCoord];
 					if (bin.length === 1) {
 					    coords = coords.concat(bin);


### PR DESCRIPTION
refs https://github.com/ingalls/pt2itp/issues/155

I think this works pretty well! And I'm not just saying that because 22207 was the zip code I grew up in / is lucky.

```
ERROR TYPE                   COUNT
------------------------------------------
DIST                           158 (0.7%)
NAME MISMATCH                21957 (98.9%)
TEXT                            92 (0.4%)

ok - 22207/712844 failed to geocode
ok - skipped 3910 entries as duplicate house numbers
root@d75e170e742b:/usr/local/src/mapbox-places-address# node
> 158 + 21957 + 92
22207
```