### PR TITLE
optimize test mode

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -72,7 +72,7 @@ function test(argv, cb) {
 
     if (argv.limit) argv.limit = parseInt(argv.limit);
     argv.dupes = !!argv.dupes;
-    let dupeCount = 0;
+    let dupeCount = { ungeocodable: 0, duplicative: 0 };
 
     const pool = new pg.Pool({
         max: 10,
@@ -142,7 +142,11 @@ function test(argv, cb) {
                             for (let row of rows) {
                                 row.geom = JSON.parse(row.geom);
 
-                                // by default, don't query for address numbers that appear >1x in a single address cluster
+                                // by default, avoid making pointless queries to identical house numbers along the same street
+                                // street. these sets of identical house numbers come in two flavors:
+                                // - ungeocodable: ones w/ separation >1km. these are not geocoded at all.
+                                // - duplicative: sets that are more closely grouped. from these, one is geocoded.
+                                // tallies of each type are maintained
                                 let coords = row.geom.coordinates;
                                 if (!argv.dupes) {
                                     let binnedCoords = row.geom.coordinates.reduce((prev, cur) => {
@@ -150,26 +154,30 @@ function test(argv, cb) {
                                         prev[cur[2]].push(cur);
                                         return prev;
                                     }, {});
-				    coords = [];
-				    for (let zCoord in binnedCoords) {
-					let bin = binnedCoords[zCoord];
-					if (bin.length === 1) {
-					    coords = coords.concat(bin);
-					}
-					else {
-					    let allClose = true;
-					    for (let bi = 1; bi < bin.length; bi++) {
-						if (turf.distance(bin[0], bin[bi]) > 1) {
-						    allClose = false;
-						    break;
-						}
-					    }
-					    if (allClose)
-						coords = coords.concat(bin);
-					}
-				    }
+                                    coords = [];
+                                    for (let zCoord in binnedCoords) {
+                                        let bin = binnedCoords[zCoord];
+                                        if (bin.length === 1) {
+                                            coords = coords.concat(bin);
+                                        }
+                                        else {
+                                            let allClose = true;
+                                            for (let bi = 1; bi < bin.length; bi++) {
+                                                if (turf.distance(bin[0], bin[bi]) > 1) {
+                                                    allClose = false;
+                                                    break;
+                                                }
+                                            }
+                                            if (allClose) {
+                                                coords = coords.push(bin[0]);
+                                                dupeCount.duplicative += (bin.length - 1);
+                                            }
+                                            else {
+                                                dupeCount.ungeocodable += bin.length;
+                                            }
+                                        }
+                                    }
 
-                                    dupeCount += row.geom.coordinates.length - coords.length;
                                 }
 
                                 for (let addr of coords) {
@@ -329,8 +337,10 @@ function test(argv, cb) {
                                 }
                                 console.error();
                                 console.error(`ok - ${stats.fail}/${stats.total} failed to geocode`);
-                                if (!argv.dupes)
-                                    console.error(`ok - skipped ${dupeCount} entries as duplicate house numbers`);
+                                if (!argv.dupes) {
+                                    console.error(`ok - skipped ${dupeCount.duplicative} duplicative & proximate house numbers as redundant (these are fine)`);
+                                    console.error(`ok - skipped ${dupeCount.ungeocodable} duplicative & distant house numbers as impossible to geocode (these are less fine)`);
+                                }
                                 return cb();
                             }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -158,7 +158,7 @@ function test(argv, cb) {
                                     for (let zCoord in binnedCoords) {
                                         let bin = binnedCoords[zCoord];
                                         if (bin.length === 1) {
-                                            coords = coords.concat(bin);
+                                            coords.push(bin[0]);
                                         }
                                         else {
                                             let allClose = true;
@@ -169,7 +169,7 @@ function test(argv, cb) {
                                                 }
                                             }
                                             if (allClose) {
-                                                coords = coords.push(bin[0]);
+                                                coords.push(bin[0]);
                                                 dupeCount.duplicative += (bin.length - 1);
                                             }
                                             else {

--- a/lib/test.js
+++ b/lib/test.js
@@ -231,7 +231,7 @@ function test(argv, cb) {
 
                                 for (let r of res) {
                                     if (r === true) continue;
-                                    logResult(r[0], r[1]);                                    
+                                    logResult(r[0], r[1]);
                                 }
 
                                 bar.tick(cursor_it);
@@ -322,7 +322,7 @@ function test(argv, cb) {
 
                             if (!rows.length) {
                                 pg_done();
-                                csvOut.end(); 
+                                csvOut.end();
                                 let totalCount = Object.keys(resultTypeTotals).reduce((prev, cur) => { return prev + resultTypeTotals[cur]; }, 0);
                                 console.error();
                                 console.error('ERROR TYPE                   COUNT');


### PR DESCRIPTION
dupe-avoidance code currently looks for ungeocodable duplicates: entries in address clusters with the same house number that are too far apart for there to be hope of reliably getting a correct answer.

This is still inefficient, though: the duplicates that are close together are getting geocoded multiple times. The indeterminacy about which point comes back is still present, it's just that all of the possible points are close enough together that any of them will count as correct. This circumstance should be expected any time there are overlapping data sources (which will be often).

This PR addresses this inefficiency by only geocoding the first of a duplicate, close-together set of points. The number of points skipped is tracked, as is the number of ungeocodable points. The two are displayed separately at the end of a test run.

cc @ingalls @aaaandrea 