### PR TITLE
Fix tilebelt fxn name

### DIFF
--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -519,7 +519,7 @@ function genFeat(text, split, result, argv) {
 
     if (!centre || !verifyCenter(centre.geometry.coordinates, tiles)) {
         tmptiles = cover.tiles(split.network.geometry, { min_zoom: 14, max_zoom: 14 }); //14 is the max resolution for carmen
-        let bbox = tilebelt.tiletobbox(tmptiles[0]);
+        let bbox = tilebelt.tileToBBOX(tmptiles[0]);
         centre = [ (bbox[2] + bbox[0]) / 2, (bbox[3] + bbox[1]) / 2 ];
     } else {
         centre = centre.geometry.coordinates;


### PR DESCRIPTION
Tilebelt function name needs to be capitalized. This fxn is seldom called

cc/ @sbma44 @aaaandrea 