### PR TITLE
Fixing result logging for "NO RESULTS"

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -208,13 +208,14 @@ function test(argv, cb) {
                                         c.geocode(query, opts, (err, res) => {
                                             if (err) return done(err.toString());
 
+                                            let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
+
                                             if (!res.features.length) {
                                                 stats.fail++;
-                                                return done(null, `NO RESULTS|${query}|${opts.proximity.join(',')}`);
+                                                return done(null, ['NO RESULTS', { query: cleanQuery, queryPoint: opts.proximity.join(',')}]);
                                             }
 
                                             let matched = diacritics(tokenize(res.features[0].place_name, meta.tokens).join(' '));
-                                            let cleanQuery = diacritics(tokenize(query, meta.tokens).join(' '));
 
                                             let dist = false;
                                             if (res.features[0].geometry.type === 'Point') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,21 +1192,6 @@
         "@turf/inside": "4.6.0"
       }
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
-    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -6279,6 +6264,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6301,6 +6296,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsts/-/jsts-1.3.0.tgz",
       "integrity": "sha1-6Tp2+XrJvafUYl2dZHDw1grIDkU="
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "kebab-case": {
       "version": "1.0.0",
@@ -7898,13 +7898,13 @@
       "integrity": "sha1-ElGkuixEqS32mJvQKdoSGk8hCbA=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "concat-stream": "1.5.2",
         "defined": "1.0.0",
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.4.0",
@@ -9757,6 +9757,14 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-extended": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
@@ -9792,14 +9800,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0",
         "function-bind": "1.1.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {


### PR DESCRIPTION
This is where the mysterious "N" result code was coming from.  While all of the other results were arrays, this one was a string.  So in `addrQ.awaitAll` below:

```javascript
                                 for (let r of res) {
                                     if (r === true) continue;
                                     logResult(r[0], r[1]);
                                 }
```

 `r[0]` is called on the string (which starts with "N"), rather than on an array, as it does for the other result types.


@sbma44 one beer please.