### PR TITLE
update carmen and add sqlite3@3.1.8 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Nicholas Ingalls <nicholas.ingalls@gmail.com>",
   "license": "GPL-3.0",
   "dependencies": {
-    "@mapbox/carmen": "^22.4.3",
+    "@mapbox/carmen": "24.0.0",
     "@mapbox/geocoder-abbreviations": "^1.8.0",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
@@ -36,6 +36,7 @@
     "progress": "^2.0.0",
     "simple-statistics": "^4.1.1",
     "split": "^1.0.0",
+    "sqlite3": "3.1.8",
     "talisman": "^0.19.1",
     "turf-line-slice-at-intersection": "^1.0.1",
     "wellknown": "^0.5.0"


### PR DESCRIPTION
This is meant to resolve 2 issues. 

1. Update Carmen dependency version to the recent version of Carmen. 
2. Add a SQLite3@3.1.8 to divert this failure: 
```
npm ERR! path /usr/local/src/mapbox-places-address/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/npmlog/node_modules/are-we-there-yet/node_modules/delegates
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall rename
npm ERR! enoent ENOENT: no such file or directory, rename '/usr/local/src/mapbox-places-address/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/npmlog/node_modules/are-we-there-yet/node_modules/delegates' -> '/usr/local/src/mapbox-places-address/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/npmlog/node_modules/are-we-there-yet/node_modules/.delegates.DELETE'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /usr/local/.npm/_logs/2017-09-04T09_15_12_596Z-debug.log
```
NOTE: The SQLite3@3.1.8 dependency should be removed pending the resolution to [this node-sqlite3 issue](https://github.com/mapbox/node-sqlite3/issues/866)