### PR TITLE
remove peg to sqlite3@3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "progress": "^2.0.0",
     "simple-statistics": "^4.1.1",
     "split": "^1.0.0",
-    "sqlite3": "3.1.8",
     "talisman": "^0.19.1",
     "turf-line-slice-at-intersection": "^1.0.1",
     "wellknown": "^0.5.0"


### PR DESCRIPTION
per https://github.com/ingalls/pt2itp/pull/178#issuecomment-328143270 the peg to sqlite@3.1.8 can be removed.  Tested this on Amazon ECS, release 4.9.27-14.31.amzn1.x86_64