### PR TITLE
changing any null text fields to empty string

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -417,27 +417,41 @@ class Cluster {
 
                 let str = Object.keys(names);
 
-                str.sort((a, b) => {
-                    return names[b] - names[a];
-                });
 
-                if (!str.length) return cb();
+                if (!str.length) {
+                    this.pool.query(`
+                        UPDATE
+                            network
+                        SET
+                            named = FALSE
+                        WHERE
+                            id = ${id}
+                    `, (err, res) => {
+                        return cb(err);
+                    });
+                }
+                else {
+                    str.sort((a, b) => {
+                        return names[b] - names[a];
+                    });
 
-                let text = JSON.parse(str[0]);
+                    let text = JSON.parse(str[0]);
 
-                this.pool.query(`
-                    UPDATE
-                        network
-                    SET
-                        text = '${text[0]}',
-                        text_tokenless = '${text[1]}',
-                        _text = '${text[2]}',
-                        named = TRUE
-                    WHERE
-                        id = ${id}
-                `, (err, res) => {
-                    return cb(err);
-                });
+
+                    this.pool.query(`
+                        UPDATE
+                            network
+                        SET
+                            text = '${text[0]}',
+                            text_tokenless = '${text[1]}',
+                            _text = '${text[2]}',
+                            named = TRUE
+                        WHERE
+                            id = ${id}
+                    `, (err, res) => {
+                        return cb(err);
+                    });
+                }
             });
         });
     }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -418,7 +418,7 @@ class Cluster {
                 let str = Object.keys(names);
 
 
-                if (!str.length) {
+                if (res.rows.length == 0 || !str.length) {
                     this.pool.query(`
                         UPDATE
                             network

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -408,20 +408,23 @@ class Cluster {
                 if (err) return cb(err);
 
                 for (let res_it = 0; res_it < res.rows.length; res_it++) {
-                    let text = JSON.stringify([
-                        res.rows[res_it].text,
-                        res.rows[res_it].text_tokenless,
-                        res.rows[res_it]._text
-                    ]);
+                    // only consider results that have non-empty _text strings
+                    if (res.rows[res_it]._text) {
+                        let text = JSON.stringify([
+                            res.rows[res_it].text,
+                            res.rows[res_it].text_tokenless,
+                            res.rows[res_it]._text
+                        ]);
 
-                    if (!names[text]) names[text] = 1;
-                    else names[text]++;
+                        if (!names[text]) names[text] = 1;
+                        else names[text]++;
+                    }
                 }
 
-                let str = Object.keys(names);
+                let namelist = Object.keys(names);
 
 
-                if (res.rows.length == 0 || !str.length) {
+                if (res.rows.length == 0 || !namelist.length) {
                     this.pool.query(`
                         UPDATE
                             network
@@ -434,20 +437,30 @@ class Cluster {
                     });
                 }
                 else {
-                    str.sort((a, b) => {
+                    namelist.sort((a, b) => {
                         return names[b] - names[a];
                     });
 
-                    let text = JSON.parse(str[0]);
+                    let new_text_values = JSON.parse(namelist[0]);
 
+                    for (let k = 0; k < new_text_values.length; k++) {
+                        if (!new_text_values[k]) {
+                            // anything falsey should become empty string
+                            new_text_values[k] = '';
+                        }
+                        else {
+                            // any string needs to be made sql safe: replace single quote with two single quotes
+                            new_text_values[k] = new_text_values[k].replace('\'', '\'\'');
+                        }
+                    }
 
                     this.pool.query(`
                         UPDATE
                             network
                         SET
-                            text = '${text[0]}',
-                            text_tokenless = '${text[1]}',
-                            _text = '${text[2]}',
+                            text = '${new_text_values[0]}',
+                            text_tokenless = '${new_text_values[1]}',
+                            _text = '${new_text_values[2]}',
                             named = TRUE
                         WHERE
                             id = ${id}

--- a/lib/index.js
+++ b/lib/index.js
@@ -445,7 +445,7 @@ class Index {
                 DELETE FROM address WHERE length(number::TEXT) > 10;
 
                 UPDATE address SET geom = ST_SetSRID(ST_MakePoint(substring(lon from 1 for 10)::NUMERIC, substring(lat from 1 for 10)::NUMERIC, number), 4326);
-                UPDATE address SET text='', _text='', text_tokenless='' where _text is null;
+                UPDATE address SET text='', _text='', text_tokenless='' where text is null;
 
                 CREATE INDEX address_idx ON address (text);
                 CREATE INDEX address_gix ON address USING GIST (geom);
@@ -461,7 +461,7 @@ class Index {
                 BEGIN;
 
                 UPDATE network SET geom = ST_SetSRID(ST_GeomFromGeoJSON(geomtext), 4326);
-                UPDATE network SET text='', _text='', text_tokenless='' where _text is null;
+                UPDATE network SET text='', _text='', text_tokenless='' where text is null;
 
                 CREATE INDEX network_idx ON network (text);
                 CREATE INDEX network_gix ON network USING GIST (geom);

--- a/lib/index.js
+++ b/lib/index.js
@@ -445,6 +445,7 @@ class Index {
                 DELETE FROM address WHERE length(number::TEXT) > 10;
 
                 UPDATE address SET geom = ST_SetSRID(ST_MakePoint(substring(lon from 1 for 10)::NUMERIC, substring(lat from 1 for 10)::NUMERIC, number), 4326);
+                UPDATE address SET text='', _text='', text_tokenless='' where _text is null;
 
                 CREATE INDEX address_idx ON address (text);
                 CREATE INDEX address_gix ON address USING GIST (geom);
@@ -460,6 +461,7 @@ class Index {
                 BEGIN;
 
                 UPDATE network SET geom = ST_SetSRID(ST_GeomFromGeoJSON(geomtext), 4326);
+                UPDATE network SET text='', _text='', text_tokenless='' where _text is null;
 
                 CREATE INDEX network_idx ON network (text);
                 CREATE INDEX network_gix ON network USING GIST (geom);

--- a/lib/map.js
+++ b/lib/map.js
@@ -225,8 +225,6 @@ function main(argv, cb) {
                             console.error('ok - named unnamed streets ' + batch);
                             batch++;
 
-                            //pg_done();
-
                             bar.tick(rows.length);
                             return iterate();
                         });

--- a/lib/map.js
+++ b/lib/map.js
@@ -212,7 +212,8 @@ function main(argv, cb) {
                         const nameQ = Queue();
 
                         for (let row_it = 0; row_it < rows.length; row_it++) {
-                            nameQ.defer(cluster.name, rows[row_it].id);
+                            //nameQ.defer(cluster.name, rows[row_it].id);
+                            nameQ.defer((id, done) => { cluster.name(id, done) }, rows[row_it].id);
                         }
 
                         nameQ.await((err) => {

--- a/lib/map.js
+++ b/lib/map.js
@@ -212,8 +212,11 @@ function main(argv, cb) {
                         const nameQ = Queue();
 
                         for (let row_it = 0; row_it < rows.length; row_it++) {
-                            //nameQ.defer(cluster.name, rows[row_it].id);
-                            nameQ.defer((id, done) => { cluster.name(id, done) }, rows[row_it].id);
+                            let row_id = rows[row_it].id;
+
+                            nameQ.defer((id, done) => {
+                                cluster.name(id, done);
+                            }, row_id);
                         }
 
                         nameQ.await((err) => {
@@ -222,7 +225,7 @@ function main(argv, cb) {
                             console.error('ok - named unnamed streets ' + batch);
                             batch++;
 
-                            pg_done();
+                            //pg_done();
 
                             bar.tick(rows.length);
                             return iterate();

--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -104,7 +104,7 @@ class Orphan {
             if (err) return cb(err);
 
             const cursor = client.query(new Cursor(`
-                SELECT _text AS network_text, _text AS address_text,  ST_AsGeoJSON(geom) AS geom FROM network_cluster WHERE address IS NULL AND _text IS NOT NULL;
+                SELECT _text AS network_text, _text AS address_text,  ST_AsGeoJSON(geom) AS geom FROM network_cluster WHERE address IS NULL AND _text != '';
             `));
 
             return iterate();


### PR DESCRIPTION
Null values in `address` and `network` tables' text fields shouldn't be allowed, but they're getting created because the `COPY` commands are treating empty strings as null:

```javascript
for (let child of nursery) {
    netQ.defer((output, done) => {
        self.pool.query(`
            COPY network (text, text_tokenless, _text, geomtext)
            FROM '${output}' WITH CSV DELIMITER '|' QUOTE E'\b' NULL AS '';
        `, (err) => {
            if (err) return done(err);

            fs.unlink(output, (err) => {
                return done(err);
            });
        });
    }, child.output);
}
```

That's fine, we need it for other values that are stored as empty strings in the PSV file.  it has the unfortunate side effect, though, of creating null values in the text fields.

```
mbpl_us_mt_address_both=# select count(*) from network;
 count
--------
 105584
(1 row)

mbpl_us_mt_address_both=# select count(*) from network where _text is null;
 count
-------
 45222
(1 row)
```