### PR TITLE
Add errors as % of total addresses to test stats

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -361,11 +361,12 @@ function test(argv, cb) {
                                     for (let i=0; i < 34 - (errType.length + resultTypeTotals[errType].toString().length); i++)
                                         process.stderr.write(' ');
                                     process.stderr.write(resultTypeTotals[errType].toString());
-                                    let pct = (100 * resultTypeTotals[errType] / totalCount).toFixed(1).toString();
-                                    console.error(` (${pct}%)`);
+                                    let pctOfErrors = (100 * resultTypeTotals[errType] / totalCount).toFixed(1).toString();
+                                    let pctOfTotal = (100 * resultTypeTotals[errType] / stats.total).toFixed(1).toString();
+                                    console.error(` (${pctOfErrors}% of errors | ${pctOfTotal}% of total addresses)`);
                                 }
                                 console.error();
-                                console.error(`ok - ${stats.fail}/${stats.total} failed to geocode`);
+                                console.error(`ok - ${stats.fail}/${stats.total} (${(stats.fail/stats.total).toFixed(1).toString()}%) failed to geocode`);
                                 if (!argv.dupes) {
                                     console.error(`ok - skipped ${dupeCount.duplicative} duplicative & proximate house numbers as redundant (these are fine)`);
                                     console.error(`ok - skipped ${dupeCount.ungeocodable} duplicative & distant house numbers as impossible to geocode (these are less fine)`);

--- a/lib/test.js
+++ b/lib/test.js
@@ -302,7 +302,6 @@ function test(argv, cb) {
                                     }
 
                                     stats.total++;
-                                    stats.fail++;
                                     logResult('NOT MATCHED TO NETWORK', { addressText: `${addr[2]} ${row._text}`, queryPoint: addr.join(',') });
                                 }
                             }
@@ -390,7 +389,6 @@ function test(argv, cb) {
                                 let softMatch = (normalizedNtext === normalizedAtext);
 
                                 stats.total++;
-                                stats.fail++;
                                 logResult('NAME MISMATCH ' + (softMatch ? '(SOFT)' : '(HARD)'), { networkText: ntext, addressText: `${atext}`, queryPoint: JSON.parse(row.center).coordinates });
                             }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -363,10 +363,12 @@ function test(argv, cb) {
                                     process.stderr.write(resultTypeTotals[errType].toString());
                                     let pctOfErrors = (100 * resultTypeTotals[errType] / totalCount).toFixed(1).toString();
                                     let pctOfTotal = (100 * resultTypeTotals[errType] / stats.total).toFixed(1).toString();
-                                    console.error(` (${pctOfErrors}% of errors | ${pctOfTotal}% of total addresses)`);
-                                }
+                                    console.error(` (${Array(4 - pctOfErrors.length + 1).join(' ')}
+                                        ${pctOfErrors}% of errors |
+                                        ${Array(4 - pctOfTotal.length + 1).join(' ')}
+                                        ${pctOfTotal}% of total addresses)`);
                                 console.error();
-                                console.error(`ok - ${stats.fail}/${stats.total} (${(stats.fail/stats.total).toFixed(1).toString()}%) failed to geocode`);
+                                console.error(`ok - ${stats.fail}/${stats.total} (${(100 * stats.fail / stats.total).toFixed(1).toString()}%) failed to geocode`);
                                 if (!argv.dupes) {
                                     console.error(`ok - skipped ${dupeCount.duplicative} duplicative & proximate house numbers as redundant (these are fine)`);
                                     console.error(`ok - skipped ${dupeCount.ungeocodable} duplicative & distant house numbers as impossible to geocode (these are less fine)`);


### PR DESCRIPTION
Tweaked pt2itp tests to make the output more useful.

### Changes

- [X] removed `NAME MISMATCH` and `NOT MATCHED TO NETWORK` errors from failed to geocode total since these addresses can be geocoded. Failed to geocode now consists of `DIST`, `NAME MISMATCH (HARD)`, `NAME MISMATCH (SOFT)`, `NO RESULTS`, and `TEXT` errors.
- [X] added errors as a % of total addresses to summary stats
- [X] added failed to geocode errors as a % of total addresses to summary 

### Next steps

- [ ] Will test locally to make sure the formatting looks 👌 
- [x] review by @ingalls 🌮 
- [ ] 🚀 