### PR TITLE
Missed closing brackets

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -394,9 +394,9 @@ function test(argv, cb) {
                                 stats.total++;
                                 logResult('NAME MISMATCH ' + (softMatch ? '(SOFT)' : '(HARD)'), { networkText: ntext, addressText: `${atext}`, queryPoint: JSON.parse(row.center).coordinates });
                             }
-
                             bar.tick(cursor_it);
                             setImmediate(iterate);
+                            }
                         });
                     }
                 });


### PR DESCRIPTION
Currently, we're running into:
```
node lib/test.js
pt2itp/lib/test.js:400
                        });
                         ^
SyntaxError: Unexpected token )
```
We're missing a closing bracket on the line before it, so this PR adds the closing bracket. Tested it out locally seems to work ! 

cc @ingalls 