### PR TITLE
Eliminate NULL text to fix split error

### DIFF
--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -38,7 +38,7 @@ class Orphan {
                 SELECT a._text AS address_text, n._text as network_text, ST_AsGeoJSON(a.geom) AS geom 
                 FROM address_cluster a 
                 LEFT JOIN network_cluster n ON a.id = n.address 
-                WHERE n.address IS NULL AND n._text != '' AND n._text IS NOT NULL;
+                WHERE n.address IS NULL AND a._text IS NOT NULL AND n._text != '' AND n._text IS NOT NULL;
             `));
 
             return iterate();
@@ -107,7 +107,9 @@ class Orphan {
             if (err) return cb(err);
 
             const cursor = client.query(new Cursor(`
-                SELECT _text AS network_text, _text AS address_text,  ST_AsGeoJSON(geom) AS geom FROM network_cluster WHERE address IS NULL AND _text != '' AND _text IS NOT null;
+                SELECT _text AS network_text, _text AS address_text, ST_AsGeoJSON(geom) AS geom 
+                FROM network_cluster 
+                WHERE address IS NULL AND _text != '' AND _text IS NOT NULL;
             `));
 
             return iterate();

--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -104,7 +104,7 @@ class Orphan {
             if (err) return cb(err);
 
             const cursor = client.query(new Cursor(`
-                SELECT _text AS network_text, _text AS address_text,  ST_AsGeoJSON(geom) AS geom FROM network_cluster WHERE address IS NULL AND _text != '';
+                SELECT _text AS network_text, _text AS address_text,  ST_AsGeoJSON(geom) AS geom FROM network_cluster WHERE address IS NULL AND _text != '' AND _text IS NOT null;
             `));
 
             return iterate();

--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -35,7 +35,10 @@ class Orphan {
             if (err) return cb(err);
 
             const cursor = client.query(new Cursor(`
-                SELECT a._text AS address_text, n._text as network_text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;
+                SELECT a._text AS address_text, n._text as network_text, ST_AsGeoJSON(a.geom) AS geom 
+                FROM address_cluster a 
+                LEFT JOIN network_cluster n ON a.id = n.address 
+                WHERE n.address IS NULL AND n._text != '' AND n._text IS NOT NULL;
             `));
 
             return iterate();


### PR DESCRIPTION
### Context:

`titlecase.js` was breaking when text was null:
```
/usr/local/src/pt2itp/lib/label/titlecase.js:63
        .split(wordBoundary)
        ^

TypeError: Cannot read property 'split' of null
    at titleCase (/usr/local/src/pt2itp/lib/label/titlecase.js:63:9)
    at Orphan.label (/usr/local/src/pt2itp/lib/label/titlecase.js:124:20)
    at rows.forEach (/usr/local/src/pt2itp/lib/orphan.js:60:53)
    at Array.forEach (native)
    at cursor.read (/usr/local/src/pt2itp/lib/orphan.js:55:26)
    at Immediate.setImmediate (/usr/local/src/pt2itp/node_modules/pg-cursor/index.js:86:7)
    at runCallback (timers.js:666:20)
    at tryOnImmediate (timers.js:639:5)
    at processImmediate [as _immediateCallback] (timers.js:611:5)
```

This PR skips null text features in the address and networks clusters by adding a check in `orphan.js`.

Let's get this merged now to unblock us and write tests for `orphan` in a future PR.

cc @ingalls and @aaaandrea 