### PR TITLE
fix matched test

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -236,7 +236,7 @@ function test(argv, cb) {
                                             return done(null, true);
 
                                         });
-                                    }, `${units.decode(addr[2])} ${row._text}`, {
+                                    }, `${units.decode(addr[2]).num} ${row._text}`, {
                                         proximity: [ addr[0], addr[1] ]
                                     });
                                 }


### PR DESCRIPTION
The string interpolation was using the return value of `unit.decode`, which is an object:

```js
/**
 * Decode a housenumber/unit ie: 1.1234 etc into its' original string value
 * @param {string} str String to encode
 * @param {Object} args Optional args
 * @return {Object} Object in format { num: String, output: boolean }
 */
decode(str, args = {}) {
```

therefore the queries being submitted looked like

```
"[object Object] CAMP GROUND RD"
```

instead of 

```
"1234 CAMP GROUND RD"
```

This PR fixes that by accessing the `num` property on the returned value.