### PR TITLE
Don't Test Ephemeral Points By Default

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -14,6 +14,7 @@ module.exports = function(argv) {
             console.log('   --index                       Path to carmen compatible index');
             console.log('   --database|--db <DATABASE>    Orignal database used to gen the index - used for addresses to test');
             console.log('   --output|-o <OUTFILE>         File to write problematic addresses to');
+            console.log('   --test-ephemeral              By default ephermal addresses are not tested, this enabled testing them');
             break;
         case ('debug'):
             console.log('');

--- a/lib/test.js
+++ b/lib/test.js
@@ -27,7 +27,7 @@ const units = new Units();
  * @param {string} resultType Class of result
  * @param {Object} result Result object to write to file
  */
-const logResult = (out, resultType, result) => {
+let logResult = (out, resultType, result) => {
     resultTypeTotals[resultType] = (resultTypeTotals[resultType] || 0) + 1;
     out.write([resultType, result.query||'', result.queryPoint||'', result.networkText||'', result.addressText||'', result.returnedPoint||'', result.distance||'']);
 };
@@ -173,6 +173,13 @@ function test(argv, cb) {
                                 // - duplicative: sets that are more closely grouped. from these, one is geocoded.
                                 // tallies of each type are maintained
                                 let coords = row.geom.coordinates;
+
+                                if (!argv['test-ephemeral']) {
+                                    row.geom.coordinates = row.geom.coordinates.filter((coords) => {
+                                        return coords[2] < 0 ? false : true;
+                                    });
+                                }
+
                                 if (!argv.dupes) {
                                     let binnedCoords = row.geom.coordinates.reduce((prev, cur) => {
                                         if (!prev[cur[2]]) prev[cur[2]] = [];
@@ -184,8 +191,7 @@ function test(argv, cb) {
                                         let bin = binnedCoords[zCoord];
                                         if (bin.length === 1) {
                                             coords.push(bin[0]);
-                                        }
-                                        else {
+                                        } else {
                                             let allClose = true;
                                             for (let bi = 1; bi < bin.length; bi++) {
                                                 if (turf.distance(bin[0], bin[bi]) > 1) {
@@ -193,11 +199,11 @@ function test(argv, cb) {
                                                     break;
                                                 }
                                             }
+
                                             if (allClose) {
                                                 coords.push(bin[0]);
                                                 dupeCount.duplicative += (bin.length - 1);
-                                            }
-                                            else {
+                                            } else {
                                                 dupeCount.ungeocodable += bin.length;
                                             }
                                         }

--- a/lib/test.js
+++ b/lib/test.js
@@ -27,7 +27,7 @@ const units = new Units();
  * @param {string} resultType Class of result
  * @param {Object} result Result object to write to file
  */
-var logResult = (out, resultType, result) => {
+const logResult = (out, resultType, result) => {
     resultTypeTotals[resultType] = (resultTypeTotals[resultType] || 0) + 1;
     out.write([resultType, result.query||'', result.queryPoint||'', result.networkText||'', result.addressText||'', result.returnedPoint||'', result.distance||'']);
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -50,6 +50,9 @@ function test(argv, cb) {
                 'name',
                 'dupes'
             ],
+            boolean: [
+                'test-ephermal'
+            ],
             alias: {
                 database: 'db',
                 output: 'o',

--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -77,7 +77,7 @@ function main(query, replacer, complex) {
  */
 function replaceToken(tokens, query) {
     let abbr = query;
-    for (var i=0; i < tokens.length; i++) {
+    for (let i = 0; i < tokens.length; i++) {
         if (tokens[i].named)
             abbr = XRegExp.replace(abbr, tokens[i].from, tokens[i].to);
         else
@@ -93,11 +93,11 @@ function replaceToken(tokens, query) {
  * @return {Array}  An array of RegExp Objects
  */
 function createGlobalReplacer(tokens) {
-    var replacers = [];
-    for (var token in tokens) {
-        var from = token;
-        var to = tokens[token];
-        var entry = {
+    const replacers = [];
+    for (let token in tokens) {
+        let from = token;
+        let to = tokens[token];
+        let entry = {
             named: false,
             from: new RegExp(from, 'gi'),
             to: to

--- a/web/index.html
+++ b/web/index.html
@@ -76,7 +76,7 @@
         }
 
         mapboxgl.accessToken = 'pk.eyJ1IjoiaW5nYWxscyIsImEiOiJjajI2Ymx4OWYwMGhtMzJxa3VyOTAzMXJjIn0.ci7utjVvmGzD8209TTFneA';
-        var map = new mapboxgl.Map({
+        const map = new mapboxgl.Map({
             container: 'map', // container id
             style: 'mapbox://styles/mapbox/streets-v9' //stylesheet location
         });


### PR DESCRIPTION
Ephemeral Points are currently points typically derived from ITP sources so already have high levels of potential DIST offset. Testing these points as sources of truth doesn't make sense.

Going to hide testing ephemeral points behind a flag which will be off by default.

Current Tests using Alaska Open Address Data & TIGER Derived Ephemeral Points
```
ERROR TYPE                   COUNT
-----------------------------------------------------------------------------------
DIST                         57395 ( 39.4% of errors |  5.6% of total addresses)
NAME MISMATCH (HARD)           822 (  0.6% of errors |  0.1% of total addresses)
NAME MISMATCH (SOFT)           212 (  0.1% of errors |  0.0% of total addresses)
NO RESULTS                     369 (  0.3% of errors |  0.0% of total addresses)
NOT MATCHED TO NETWORK       81539 ( 55.9% of errors |  7.9% of total addresses)
TEXT                          5520 (  3.8% of errors |  0.5% of total addresses)
```

New Tests:

```
ERROR TYPE                   COUNT
-----------------------------------------------------------------------------------
NAME MISMATCH (HARD)           822 (  1.0% of errors |  0.3% of total addresses)
NAME MISMATCH (SOFT)           212 (  0.3% of errors |  0.1% of total addresses)
NO RESULTS                      34 (  0.0% of errors |  0.0% of total addresses)
NOT MATCHED TO NETWORK       81539 ( 98.7% of errors | 27.3% of total addresses)
TEXT                            18 (  0.0% of errors |  0.0% of total addresses)
```

cc/ @boblannon @sbma44 @aaaandrea @lizziegooding @KaiBot3000 @aarthykc 
