### PR TITLE
Reduce NOT MATCHED Errors

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -319,7 +319,7 @@ function test(argv, cb) {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
+                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(ST_PointOnSurface(geom)) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
 
                     const bar = new prog('ok - Unmatched Addresses [:bar] :percent :etas', {
                         complete: '=',
@@ -338,24 +338,11 @@ function test(argv, cb) {
                         cursor.read(cursor_it, (err, rows) => {
                             if (err) return cb(err);
 
-                            if (!rows.length) {
-                                return diffName();
-                            }
+                            if (!rows.length) return diffName();
 
                             for (let row of rows) {
-                                row.geom = JSON.parse(row.geom);
-
-                                for (let addr of row.geom.coordinates) {
-                                    if (addr[2] % 1 != 0 && meta.units) {
-                                        let unit = parseInt(String(addr[2]).split('.')[1]);
-                                        let num = String(addr[2]).split('.')[0];
-
-                                        addr[2] = `${num}${meta.units[unit]}`;
-                                    }
-
-                                    stats.total++;
-                                    logResult('NOT MATCHED TO NETWORK', { addressText: `${addr[2]} ${row._text}`, queryPoint: addr.join(',') });
-                                }
+                                stats.total++;
+                                logResult('NOT MATCHED TO NETWORK', { addressText: row._text, queryPoint: JSON.parse(row.geom).coordinates });
                             }
 
                             bar.tick(cursor_it);

--- a/lib/test.js
+++ b/lib/test.js
@@ -319,7 +319,7 @@ function test(argv, cb) {
                 client.query('SELECT count(*) FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL;', (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(ST_PointOnSurface(geom)) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
+                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(ST_PointOnSurface(a.geom)) AS geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
 
                     const bar = new prog('ok - Unmatched Addresses [:bar] :percent :etas', {
                         complete: '=',


### PR DESCRIPTION
At the moment NOT MATCHED errors are created by finding a cluster that wasn't matched to the network and then creating an error for _every address in the cluster_.

This error case is supposed to show a disparity between the network_cluster text and the address cluster text. As such it doesn't make sense to treat this as an error for every address in the cluster.