### PR TITLE
Monozygotic Address Text/Pts

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -264,6 +264,34 @@ class Cluster {
     adoption(cb) {
         this.pool.query(`
             BEGIN;
+            -- Spatially Adjacent/Identical and text_tokenless identical
+
+            CREATE INDEX address_cluster_tokenless_idx ON address_cluster(text_tokenless);
+
+            CREATE TABLE twin AS
+                SELECT
+                    matched.id,
+                    matched._text,
+                    unmatched.id as combine,
+                    ST_CollectionExtract(ST_Collect(matched.geom, unmatched.geom),1) AS geom
+                FROM
+                    (SELECT a.id, a._text, a.text_tokenless, a.geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NOT NULL) matched,
+                    (SELECT a.id, a.text_tokenless, a.geom FROM address_cluster a LEFT JOIN network_cluster n ON a.id = n.address WHERE n.address IS NULL) unmatched
+                WHERE
+                    matched.text_tokenless = unmatched.text_tokenless
+                    AND ST_Intersects(ST_Envelope(matched.geom), ST_Envelope(unmatched.geom));
+
+            UPDATE address_cluster
+                SET geom = ST_CollectionExtract(ST_Collect(address_cluster.geom, twin.geom), 1)
+                FROM (SELECT id, ST_CollectionExtract(ST_Collect(geom), 1) AS geom FROM twin GROUP BY id) twin
+                WHERE address_cluster.id = twin.id;
+
+            DELETE FROM address_cluster
+                WHERE address_cluster.id IN (SELECT combine FROM twin);
+
+            DROP TABLE twin;
+
+            -- Identically named but spatially separated
 
             ALTER TABLE network_cluster DROP COLUMN IF EXISTS address_text;
             ALTER TABLE network_cluster ADD COLUMN address_text TEXT;
@@ -281,8 +309,8 @@ class Cluster {
             CREATE INDEX name_cluster_text_idx ON name_count (_text);
             UPDATE address_cluster ac
                  SET name_uniqueness = nc.cnt
-                 FROM name_count nc
-                 WHERE ac._text=nc._text;
+                     FROM name_count nc
+                     WHERE ac._text = nc._text;
 
             ALTER TABLE address_cluster ADD COLUMN orphan_adoptive_parent BIGINT DEFAULT NULL;
 
@@ -294,8 +322,7 @@ class Cluster {
                 FROM network_cluster n
                 WHERE
                     a.name_uniqueness > 1
-                    AND
-                    (
+                    AND (
                         a.id = n.address
                         OR
                         (

--- a/lib/map.js
+++ b/lib/map.js
@@ -339,6 +339,8 @@ function main(argv, cb) {
     }
 
     /**
+     * Case 1:
+     *
      * Adopt address_clusters that are not in proximity to matched addressa_cluster but should be matched with the same network_cluster
      *          Line 1
      * ------------------------------
@@ -346,6 +348,14 @@ function main(argv, cb) {
      *   A                      B
      *
      * By default Line 1 can only match with A or B not both,  detect these cases and group A & B together into a single cluster
+     *
+     * Case 2:
+     *
+     * Adopt address_clusters that _are_ in proxity and were not matched to an network_cluster and share a the same text_tokenless name
+     *
+     * IE:
+     *  Addr1: Spring Valley Rd (Matched to Network)
+     *  Addr2: Spring Valley (Not Matched - Identical or near identical pts)
      */
     function adopt() {
         return cluster.adoption(() => {


### PR DESCRIPTION
![screenshot from 2017-10-11 15-44-53](https://user-images.githubusercontent.com/1297009/31462554-2569c686-ae9b-11e7-9514-808ba02e3d90.png)

Seeing a lot of these. Typically it means there are 2 county level source and we should just drop one. Tis isn't always possible if a city level source is correct and the county is the one slightly off (Missing Suf)

They are hard to track/spot however and we're definitely going to have some slip in. These result in `NOT MATCHED TO NETWORK` errors in `test` mode. Instead of assuming we will catch them all in review going to add support for collapsing these.