### PR TITLE
Handle Octothorps in Highways like `HWY #35`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v12.6.2
+
+- :rocket: Strip the `#` from street names like `HWY #35`
+
 ### v12.6.1
 
 - :bug: Skip test result if it returns `undefined`

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -59,6 +59,25 @@ function map(feat, context) {
     }
 
     /**
+     * Removes the octothorpe from names like "HWY #35", to get "HWY 35"
+     * @param {string} name Name to edit
+     */
+    function reformatUSHighway(name) {
+        if (!name) return;
+
+        let octothorpePattern = new RegExp('^(HWY |HIGHWAY )(#)(\d+)$');
+
+        let match = name.match(octothorpePattern);
+        if (match) {
+            let formattedName = `${match[0]} ${match[2]}`;
+            return formattedName;
+        }
+        else {
+            return name;
+        }
+    }
+
+    /**
      * Take a name value and check for dups/synonyms and push or discard into full name list
      * @param {string} name Name to split/discard
      */
@@ -80,6 +99,10 @@ function map(feat, context) {
 
     if (context.country === 'us' && context.region) {
         preprocessSteps.push(renameUSRoutes.bind(null, context.region));
+    }
+
+    if (context.country === 'us') {
+        preprocessSteps.push(reformatUSHighway.bind(null));
     }
 
     let targetKeys = ['name', 'loc_name', 'alt_name', 'ref'];

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -65,11 +65,11 @@ function map(feat, context) {
     function reformatUSHighway(name) {
         if (!name) return;
 
-        let octothorpePattern = new RegExp('^(HWY |HIGHWAY )(#)(\d+)$');
+        let octothorpePattern = new RegExp('^(HWY |HIGHWAY )(#)(\\d+)$');
 
         let match = name.match(octothorpePattern);
         if (match) {
-            let formattedName = `${match[0]} ${match[2]}`;
+            let formattedName = `${match[1]}${match[3]}`;
             return formattedName;
         }
         else {

--- a/test/map.osmium.test.js
+++ b/test/map.osmium.test.js
@@ -156,7 +156,7 @@ test('Osmium', (t) => {
     },{country: "us", region: "pa"}), [
         { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'name' }, type: 'Feature' },
         { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'ROUTE 66' }, type: 'Feature' }], 'US Federal Route');
-    
+
     t.deepEquals(map({
         type: 'Feature',
         properties: {
@@ -172,6 +172,23 @@ test('Osmium', (t) => {
     },{country: "us", region: "pa"}), [
         { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'name' }, type: 'Feature' },
         { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'ROUTE 66' }, type: 'Feature' }], 'US State Route');
+
+    // remove octothorpes from highway names
+    t.deepEquals(map({
+        type: 'Feature',
+        properties: {
+            highway: 'motorway',
+            "@id": 3,
+            name: 'name',
+            ref: 'HWY #35'
+        },
+        geometry: {
+            type: 'LineString',
+            coordinates: [[0,0],[1,1]]
+        }
+    },{country: "us"}), [
+        { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'name' }, type: 'Feature' },
+        { geometry: { type: 'LineString', coordinates: [[0,0],[1,1]] }, properties: { id: 3, street: 'HWY 35' }, type: 'Feature' }], 'HWY # replaced');
 
     t.end();
 });


### PR DESCRIPTION
Fixes odd highway formatting that was keeping addresses from matching. 

- [x] add `#` stripping regex function `reformatUSHighway`
- [x] add testcase

