### PR TITLE
EXPERIMENTAL TOKENS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v12.6.1
+
+- :bug: Skip test result if it returns `undefined`
+
 ### v12.6.0
 
 - :tada: Introduce `testcsv` mode for testing 3rd party data against a built index

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD-2-Clause ",
   "dependencies": {
     "@mapbox/carmen": "24.1.9",
-    "@mapbox/geocoder-abbreviations": "mapbox/geocoder-abbreviations#missingAddr",
+    "@mapbox/geocoder-abbreviations": "mapbox/geocoder-abbreviations#missedAddr",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD-2-Clause ",
   "dependencies": {
     "@mapbox/carmen": "24.1.9",
-    "@mapbox/geocoder-abbreviations": "^2.0.0",
+    "@mapbox/geocoder-abbreviations": "mapbox/geocoder-abbreviations#missingAddr",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD-2-Clause ",
   "dependencies": {
     "@mapbox/carmen": "24.1.9",
-    "@mapbox/geocoder-abbreviations": "mapbox/geocoder-abbreviations#missedAddr",
+    "@mapbox/geocoder-abbreviations": "mapbox/geocoder-abbreviations#missedAbbr",
     "@mapbox/mbtiles": "^0.9.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "12.6.0",
+  "version": "12.6.1",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,9 +43,9 @@
     split "1.0.0"
     xregexp "3.1.1"
 
-"@mapbox/geocoder-abbreviations@^2.0.0":
+"@mapbox/geocoder-abbreviations@mapbox/geocoder-abbreviations#missedAbbr":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-2.1.0.tgz#86d9f272cd08f53dc7cf89f127ce0e7c6fef4c25"
+  resolved "https://codeload.github.com/mapbox/geocoder-abbreviations/tar.gz/a9a5ebaad7332985839af11f075ba704c493cda0"
   dependencies:
     tape "^4.6.3"
 


### PR DESCRIPTION
Use experimental packages to protect non-address layers from rapid iteration on the address token layer