### PR TITLE
Add Test Case for Free Radicals (address clustering -> solo addresses)

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -170,7 +170,7 @@ function main(argv, cb) {
     }
 
     /**
-     * Attempt to add names to any unanmed streets
+     * Attempt to add names to any unnamed streets
      * @param {Error} err Any errors from parent function/step
      */
     function nameNetwork(err) {
@@ -348,7 +348,7 @@ function main(argv, cb) {
      * . . .                .   .   .
      *   A                      B
      *
-     * By default Line 1 can only match with A or B not both,  detect these cases and group A & B together into a single cluster
+     * By default Line 1 can only match with A or B not both, detect these cases and group A & B together into a single cluster
      */
     function adopt() {
         return cluster.adoption(() => {
@@ -372,7 +372,7 @@ function main(argv, cb) {
     }
 
     /**
-     * Find clustest Segment in network for each address point in matched cluster and generate ITP output
+     * Find closest Segment in network for each address point in matched cluster and generate ITP output
      */
     function splitter() {
         pool.connect((err, client, pg_done) => {

--- a/lib/map.js
+++ b/lib/map.js
@@ -404,7 +404,8 @@ function main(argv, cb) {
                     child.stdout
                         .pipe(linesplit())
                         .on('data', (line) => {
-                            output.write(line + '\n');
+                            console.log('\n ok - splitter line:', line);
+                            if (line) output.write(line + '\n');
                         });
                     child.stderr.pipe(process.stderr);
 
@@ -417,7 +418,7 @@ function main(argv, cb) {
                             if (message.type === 'end') {
                                 // type == end means we have received the all-clear from a process that acted on a kill signal
                                 // nursery[message.id].active = false;
-                                console.log('\nkiddos:', nursery.length, nursery[message.id].killed);
+                                console.log('\nkiddos:', nursery.length, ", killed:", nursery[message.id].killed);
                                 nursery[message.id].kill();
 
                                 let active = nursery.some((instance) => {
@@ -427,7 +428,7 @@ function main(argv, cb) {
 
                                 if (!active) {
                                     pg_done();
-                                    console.log('kiddos:', nursery.length, nursery[message.id].killed);
+                                    console.log('kiddos:', nursery.length, ", killed:", nursery[message.id].killed);
                                     return orphans();
                                 }
                             } else {

--- a/lib/map.js
+++ b/lib/map.js
@@ -315,7 +315,7 @@ function main(argv, cb) {
                                 return (!instance.killed)
                             });
 
-                            if (active) {
+                            if (!active) {
                                 pg_done();
                                 console.error('ok - addresses assigned to linestring');
                                 return adopt();
@@ -425,7 +425,7 @@ function main(argv, cb) {
                                 });
                                 console.log('active:', active);
 
-                                if (active) {
+                                if (!active) {
                                     pg_done();
                                     console.log('kiddos:', nursery.length, nursery[message.id].killed);
                                     return orphans();

--- a/lib/map.js
+++ b/lib/map.js
@@ -283,7 +283,7 @@ function main(argv, cb) {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,
-                    total: res.rows.length++
+                    total: res.rows.length + 1
                 });
 
                 bar.tick(1); //Show progress bar
@@ -309,28 +309,23 @@ function main(argv, cb) {
                         if (message.jobs) bar.tick(message.jobs);
 
                         if (!ids.length) {
-                            nursery[message.id].active = false;
-                            nursery[message.id].child.kill();
+                            nursery[message.id].kill();
 
-                            let active = nursery.filter((instance) => {
-                                if (instance.active) return true;
-                                else return false;
+                            let active = nursery.some((instance) => {
+                                return (!instance.killed)
                             });
 
-                            if (!active.length) {
+                            if (active) {
                                 pg_done();
                                 console.error('ok - addresses assigned to linestring');
                                 return adopt();
                             }
                         } else {
-                            nursery[message.id].child.send(ids.splice(0, 10000));
+                            nursery[message.id].send(ids.splice(0,10000));
                         }
                     });
 
-                    let id = nursery.push({
-                        active: true,
-                        child: child
-                    }) - 1;
+                    let id = nursery.push(child) - 1;
 
                     child.send({
                         id: id,
@@ -387,7 +382,7 @@ function main(argv, cb) {
                     complete: '=',
                     incomplete: ' ',
                     width: 20,
-                    total: res.rows.length++
+                    total: res.rows.length + 1
                 });
 
                 bar.tick(1); //Show progress bar
@@ -421,31 +416,30 @@ function main(argv, cb) {
                         if (!ids.length) {
                             if (message.type === 'end') {
                                 // type == end means we have received the all-clear from a process that acted on a kill signal
-                                nursery[message.id].active = false;
-                                nursery[message.id].child.kill();
+                                // nursery[message.id].active = false;
+                                console.log('\nkiddos:', nursery.length, nursery[message.id].killed);
+                                nursery[message.id].kill();
 
-                                let active = nursery.filter((instance) => {
-                                    if (instance.active) return true;
-                                    else return false;
+                                let active = nursery.some((instance) => {
+                                    return (!instance.killed)
                                 });
+                                console.log('active:', active);
 
-                                if (!active.length) {
+                                if (active) {
                                     pg_done();
+                                    console.log('kiddos:', nursery.length, nursery[message.id].killed);
                                     return orphans();
                                 }
                             } else {
                                 // send kill signal so the pgpool can be shut down properly
-                                nursery[message.id].child.send({ id: message.id, type: 'end' });
+                                nursery[message.id].send({ id: message.id, type: 'end' });
                             }
                         } else {
-                            nursery[message.id].child.send(ids.splice(0, 1000));
+                            nursery[message.id].send(ids.splice(0, 1000));
                         }
                     });
 
-                    let id = nursery.push({
-                        active: true,
-                        child: child
-                    }) - 1;
+                    let id = nursery.push(child) - 1;
 
                     opts = {
                         id: id,

--- a/test/fixtures/cardinal-address.geojson
+++ b/test/fixtures/cardinal-address.geojson
@@ -1,8 +1,8 @@
-{"type": "Feature","properties": {"street": "Orchard St W","number": 1},"geometry": {"type": "Point","coordinates": [-102.03595161437988,45.08103619068379]}}
-{"type": "Feature","properties": {"street": "Orchard St W","number": 5},"geometry": {"type": "Point","coordinates": [-102.03011512756348,45.081096796213956]}}
-{"type": "Feature","properties": {"street": "Orchard St W","number": 9},"geometry": {"type": "Point","coordinates": [-102.02178955078125,45.08103619068379]}}
-{"type": "Feature","properties": {"street": "Orchard St E","number": 11},"geometry": {"type": "Point","coordinates": [-102.01286315917969,45.08103619068379]}}
-{"type": "Feature","properties": {"street": "Orchard St E","number": 15},"geometry": {"type": "Point","coordinates": [-102.00522422790526,45.081157401679846]}}
-{"type": "Feature","properties": {"street": "Orchard St","number": 3},"geometry": {"type": "Point","coordinates": [-102.03337669372559,45.080581647158354]}}
-{"type": "Feature","properties": {"street": "Orchard St","number": 7},"geometry": {"type": "Point","coordinates": [-102.02629566192627,45.08070285911873]}}
-{"type": "Feature","properties": {"street": "Orchard St","number": 13},"geometry": {"type": "Point","coordinates": [-102.00908660888672,45.08036952560893]
+{"type": "Feature","properties": {"street": "Orchard Road W","number": 1},"geometry": {"type": "Point","coordinates": [-102.03595161437988,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard Road W","number": 5},"geometry": {"type": "Point","coordinates": [-102.03011512756348,45.081096796213956]}}
+{"type": "Feature","properties": {"street": "Orchard Road W","number": 9},"geometry": {"type": "Point","coordinates": [-102.02178955078125,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard Road E","number": 11},"geometry": {"type": "Point","coordinates": [-102.01286315917969,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard Road E","number": 15},"geometry": {"type": "Point","coordinates": [-102.00522422790526,45.081157401679846]}}
+{"type": "Feature","properties": {"street": "Orchard Road","number": 3},"geometry": {"type": "Point","coordinates": [-102.03337669372559,45.080581647158354]}}
+{"type": "Feature","properties": {"street": "Orchard Road","number": 7},"geometry": {"type": "Point","coordinates": [-102.02629566192627,45.08070285911873]}}
+{"type": "Feature","properties": {"street": "Orchard Road","number": 13},"geometry": {"type": "Point","coordinates": [-102.00908660888672,45.08036952560893]

--- a/test/fixtures/cardinal-address.geojson
+++ b/test/fixtures/cardinal-address.geojson
@@ -1,0 +1,8 @@
+{"type": "Feature","properties": {"street": "Orchard St W","number": 1},"geometry": {"type": "Point","coordinates": [-102.03595161437988,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard St W","number": 5},"geometry": {"type": "Point","coordinates": [-102.03011512756348,45.081096796213956]}}
+{"type": "Feature","properties": {"street": "Orchard St W","number": 9},"geometry": {"type": "Point","coordinates": [-102.02178955078125,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard St E","number": 11},"geometry": {"type": "Point","coordinates": [-102.01286315917969,45.08103619068379]}}
+{"type": "Feature","properties": {"street": "Orchard St E","number": 15},"geometry": {"type": "Point","coordinates": [-102.00522422790526,45.081157401679846]}}
+{"type": "Feature","properties": {"street": "Orchard St","number": 3},"geometry": {"type": "Point","coordinates": [-102.03337669372559,45.080581647158354]}}
+{"type": "Feature","properties": {"street": "Orchard St","number": 7},"geometry": {"type": "Point","coordinates": [-102.02629566192627,45.08070285911873]}}
+{"type": "Feature","properties": {"street": "Orchard St","number": 13},"geometry": {"type": "Point","coordinates": [-102.00908660888672,45.08036952560893]

--- a/test/fixtures/cardinal-network.geojson
+++ b/test/fixtures/cardinal-network.geojson
@@ -1,0 +1,2 @@
+{"type": "Feature","properties": {"id": 1,"street": "Orchard Road E"},"geometry": {"type": "LineString","coordinates": [[-102.00016021728516,45.08212708039077],[-102.01655387878418,45.08206647595349]]}}
+{"type": "Feature","properties": {"id": 1,"street": "Orchard Road W"},"geometry": {"type": "LineString","coordinates": [[-102.01724052429199,45.08206647595349],[-102.03758239746094,45.08206647595349]]}}

--- a/test/fixtures/cardinal-network.geojson
+++ b/test/fixtures/cardinal-network.geojson
@@ -1,2 +1,2 @@
 {"type": "Feature","properties": {"id": 1,"street": "Orchard Road E"},"geometry": {"type": "LineString","coordinates": [[-102.00016021728516,45.08212708039077],[-102.01655387878418,45.08206647595349]]}}
-{"type": "Feature","properties": {"id": 1,"street": "Orchard Road W"},"geometry": {"type": "LineString","coordinates": [[-102.01724052429199,45.08206647595349],[-102.03758239746094,45.08206647595349]]}}
+{"type": "Feature","properties": {"id": 2,"street": "Orchard Road W"},"geometry": {"type": "LineString","coordinates": [[-102.01724052429199,45.08206647595349],[-102.03758239746094,45.08206647595349]]}}

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -43,8 +43,6 @@ test('map - db error', (t) => {
     });
 });
 
-// new test
-// runs map.js
 test('map - cardinal clustering', (t) => {
     worker({
         'in-address': './test/fixtures/cardinal-address.geojson',
@@ -64,7 +62,18 @@ test('map - cardinal clustering', (t) => {
 
             feat = JSON.parse(line);
 
-            // things to check
+            //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
+            //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this
+            //if (feat.properties['carmen:text'] === 'Muscat Street') checkFixture(feat, 'muscat-st');
+            //if (feat.properties['carmen:text'] === 'Park Road,Parsi Road') checkFixture(feat, 'park-rd');
+            //if (feat.properties['carmen:text'] === 'Teck Lim Road') checkFixture(feat, 'teck-lim');
+            //if (feat.properties['carmen:text'] === 'Jalan Kelempong') checkFixture(feat, 'jalam-kelempong');
+            //if (feat.properties['carmen:text'] === 'Tomlinson Road,Tomlison Road') checkFixture(feat, 'tomlinson');
+            //if (feat.properties['carmen:text'] === 'Jalan Sejarah') checkFixture(feat, 'jalan-sejrah');
+            //if (feat.properties['carmen:text'] === 'Changi South Street 3') checkFixture(feat, 'changi');
+            //if (feat.properties['carmen:text'] === 'Lorong 21a Geylang') checkFixture(feat, 'lorong');
+            //if (feat.properties['carmen:text'] === 'Ang Mo Kio Industrial Park 3') checkFixture(feat, 'ang-mo');
+            //if (feat.properties['carmen:text'] === 'De Souza Avenue') checkFixture(feat, 'de-souza');
         });
 
         rl.on('error', t.error);
@@ -73,28 +82,8 @@ test('map - cardinal clustering', (t) => {
             fs.unlinkSync('/tmp/itp.geojson');
             t.end();
         });
-
-        /**
-         * Standard Fixture compare/update
-         * @param {Object} res returned result
-         * @param {string} fixture Path to expected result file
-         */
-        function checkFixture(res, fixture) {
-            t.ok(res.id);
-            delete res.id;
-
-            let known = JSON.parse(fs.readFileSync(path.resolve(__dirname, `./fixtures/cardinal-${fixture}`)));
-
-            t.deepEquals(res, known);
-
-            if (process.env.UPDATE) {
-                t.fail();
-                fs.writeFileSync(path.resolve(__dirname, `./fixtures/cardinal-${fixture}`), JSON.stringify(res, null, 4));
-            }
-        }
     });
 });
-
 
 test('drop cardinal database', (t) => {
     let pool = new pg.Pool({
@@ -136,8 +125,6 @@ test.skip('map - good run', (t) => {
             if (!line) return;
 
             feat = JSON.parse(line);
-
-            console.log('test feat:', feat.properties);
 
             //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
             //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -59,21 +59,7 @@ test('map - cardinal clustering', (t) => {
 
         rl.on('line', (line) => {
             if (!line) return;
-
-            feat = JSON.parse(line);
-
-            //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
-            //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this
-            //if (feat.properties['carmen:text'] === 'Muscat Street') checkFixture(feat, 'muscat-st');
-            //if (feat.properties['carmen:text'] === 'Park Road,Parsi Road') checkFixture(feat, 'park-rd');
-            //if (feat.properties['carmen:text'] === 'Teck Lim Road') checkFixture(feat, 'teck-lim');
-            //if (feat.properties['carmen:text'] === 'Jalan Kelempong') checkFixture(feat, 'jalam-kelempong');
-            //if (feat.properties['carmen:text'] === 'Tomlinson Road,Tomlison Road') checkFixture(feat, 'tomlinson');
-            //if (feat.properties['carmen:text'] === 'Jalan Sejarah') checkFixture(feat, 'jalan-sejrah');
-            //if (feat.properties['carmen:text'] === 'Changi South Street 3') checkFixture(feat, 'changi');
-            //if (feat.properties['carmen:text'] === 'Lorong 21a Geylang') checkFixture(feat, 'lorong');
-            //if (feat.properties['carmen:text'] === 'Ang Mo Kio Industrial Park 3') checkFixture(feat, 'ang-mo');
-            //if (feat.properties['carmen:text'] === 'De Souza Avenue') checkFixture(feat, 'de-souza');
+            console.log('ok - line:', line);
         });
 
         rl.on('error', t.error);

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -45,13 +45,13 @@ test('map - db error', (t) => {
 
 // new test
 // runs map.js
-test.skip('map - cardinal clustering', (t) => {
+test('map - cardinal clustering', (t) => {
     worker({
         'in-address': './test/fixtures/cardinal-address.geojson',
         'in-network': './test/fixtures/cardinal-network.geojson',
         output: '/tmp/itp.geojson',
         debug: true,
-        db: 'pt_test_cardinal'
+        db: 'pt_test'
     }, (err, res) => {
         t.error(err);
 
@@ -64,18 +64,7 @@ test.skip('map - cardinal clustering', (t) => {
 
             feat = JSON.parse(line);
 
-            //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
-            //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this
-            //if (feat.properties['carmen:text'] === 'Muscat Street') checkFixture(feat, 'muscat-st');
-            //if (feat.properties['carmen:text'] === 'Park Road,Parsi Road') checkFixture(feat, 'park-rd');
-            //if (feat.properties['carmen:text'] === 'Teck Lim Road') checkFixture(feat, 'teck-lim');
-            //if (feat.properties['carmen:text'] === 'Jalan Kelempong') checkFixture(feat, 'jalam-kelempong');
-            //if (feat.properties['carmen:text'] === 'Tomlinson Road,Tomlison Road') checkFixture(feat, 'tomlinson');
-            //if (feat.properties['carmen:text'] === 'Jalan Sejarah') checkFixture(feat, 'jalan-sejrah');
-            //if (feat.properties['carmen:text'] === 'Changi South Street 3') checkFixture(feat, 'changi');
-            //if (feat.properties['carmen:text'] === 'Lorong 21a Geylang') checkFixture(feat, 'lorong');
-            //if (feat.properties['carmen:text'] === 'Ang Mo Kio Industrial Park 3') checkFixture(feat, 'ang-mo');
-            //if (feat.properties['carmen:text'] === 'De Souza Avenue') checkFixture(feat, 'de-souza');
+            // things to check
         });
 
         rl.on('error', t.error);
@@ -94,84 +83,24 @@ test.skip('map - cardinal clustering', (t) => {
             t.ok(res.id);
             delete res.id;
 
-            let known = JSON.parse(fs.readFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`)));
+            let known = JSON.parse(fs.readFileSync(path.resolve(__dirname, `./fixtures/cardinal-${fixture}`)));
 
             t.deepEquals(res, known);
 
             if (process.env.UPDATE) {
                 t.fail();
-                fs.writeFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`), JSON.stringify(res, null, 4));
+                fs.writeFileSync(path.resolve(__dirname, `./fixtures/cardinal-${fixture}`), JSON.stringify(res, null, 4));
             }
         }
     });
 });
 
-test('map - good run', (t) => {
-    worker({
-        'in-address': './test/fixtures/sg-address.geojson',
-        'in-network': './test/fixtures/sg-network.geojson',
-        output: '/tmp/itp.geojson',
-        debug: true,
-        db: 'pt_test_good'
-    }, (err, res) => {
-        t.error(err);
 
-        rl = ReadLine.createInterface({
-            input: fs.createReadStream('/tmp/itp.geojson')
-        });
-
-        rl.on('line', (line) => {
-            if (!line) return;
-
-            feat = JSON.parse(line);
-
-            //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
-            //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this
-            //if (feat.properties['carmen:text'] === 'Muscat Street') checkFixture(feat, 'muscat-st');
-            //if (feat.properties['carmen:text'] === 'Park Road,Parsi Road') checkFixture(feat, 'park-rd');
-            //if (feat.properties['carmen:text'] === 'Teck Lim Road') checkFixture(feat, 'teck-lim');
-            //if (feat.properties['carmen:text'] === 'Jalan Kelempong') checkFixture(feat, 'jalam-kelempong');
-            //if (feat.properties['carmen:text'] === 'Tomlinson Road,Tomlison Road') checkFixture(feat, 'tomlinson');
-            //if (feat.properties['carmen:text'] === 'Jalan Sejarah') checkFixture(feat, 'jalan-sejrah');
-            //if (feat.properties['carmen:text'] === 'Changi South Street 3') checkFixture(feat, 'changi');
-            //if (feat.properties['carmen:text'] === 'Lorong 21a Geylang') checkFixture(feat, 'lorong');
-            //if (feat.properties['carmen:text'] === 'Ang Mo Kio Industrial Park 3') checkFixture(feat, 'ang-mo');
-            //if (feat.properties['carmen:text'] === 'De Souza Avenue') checkFixture(feat, 'de-souza');
-        });
-
-        rl.on('error', t.error);
-
-        rl.on('close', () => {
-            fs.unlinkSync('/tmp/itp.geojson');
-            t.end();
-        });
-
-        /**
-         * Standard Fixture compare/update
-         * @param {Object} res returned result
-         * @param {string} fixture Path to expected result file
-         */
-        function checkFixture(res, fixture) {
-            t.ok(res.id);
-            delete res.id;
-
-            let known = JSON.parse(fs.readFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`)));
-
-            t.deepEquals(res, known);
-
-            if (process.env.UPDATE) {
-                t.fail();
-                fs.writeFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`), JSON.stringify(res, null, 4));
-            }
-        }
-    });
-});
-
-test.skip('drop cardinal database', (t) => {
+test('drop cardinal database', (t) => {
     let pool = new pg.Pool({
         max: 10,
         user: 'postgres',
-        database: 'pt_test_cardinal',
+        database: 'pt_test',
         idleTimeoutMillis: 30000
     });
 
@@ -189,11 +118,74 @@ test.skip('drop cardinal database', (t) => {
     });
 });
 
-test('drop good-run database', (t) => {
+test.skip('map - good run', (t) => {
+    worker({
+        'in-address': './test/fixtures/sg-address.geojson',
+        'in-network': './test/fixtures/sg-network.geojson',
+        output: '/tmp/itp.geojson',
+        debug: true,
+        db: 'pt_test'
+    }, (err, res) => {
+        t.error(err);
+
+        rl = ReadLine.createInterface({
+            input: fs.createReadStream('/tmp/itp.geojson')
+        });
+
+        rl.on('line', (line) => {
+            if (!line) return;
+
+            feat = JSON.parse(line);
+
+            console.log('test feat:', feat.properties);
+
+            //TODO PT2ITP is not deterministic and subsequent runs can change the output value based on unordered operations.
+            //      For these tests to function properly a full deterministic quest will have to be pursued. We should do this
+            //if (feat.properties['carmen:text'] === 'Muscat Street') checkFixture(feat, 'muscat-st');
+            //if (feat.properties['carmen:text'] === 'Park Road,Parsi Road') checkFixture(feat, 'park-rd');
+            //if (feat.properties['carmen:text'] === 'Teck Lim Road') checkFixture(feat, 'teck-lim');
+            //if (feat.properties['carmen:text'] === 'Jalan Kelempong') checkFixture(feat, 'jalam-kelempong');
+            //if (feat.properties['carmen:text'] === 'Tomlinson Road,Tomlison Road') checkFixture(feat, 'tomlinson');
+            //if (feat.properties['carmen:text'] === 'Jalan Sejarah') checkFixture(feat, 'jalan-sejrah');
+            //if (feat.properties['carmen:text'] === 'Changi South Street 3') checkFixture(feat, 'changi');
+            //if (feat.properties['carmen:text'] === 'Lorong 21a Geylang') checkFixture(feat, 'lorong');
+            //if (feat.properties['carmen:text'] === 'Ang Mo Kio Industrial Park 3') checkFixture(feat, 'ang-mo');
+            //if (feat.properties['carmen:text'] === 'De Souza Avenue') checkFixture(feat, 'de-souza');
+        });
+
+        rl.on('error', t.error);
+
+        rl.on('close', () => {
+            fs.unlinkSync('/tmp/itp.geojson');
+            t.end();
+        });
+
+        /**
+         * Standard Fixture compare/update
+         * @param {Object} res returned result
+         * @param {string} fixture Path to expected result file
+         */
+        function checkFixture(res, fixture) {
+            t.ok(res.id);
+            delete res.id;
+
+            let known = JSON.parse(fs.readFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`)));
+
+            t.deepEquals(res, known);
+
+            if (process.env.UPDATE) {
+                t.fail();
+                fs.writeFileSync(path.resolve(__dirname, `./fixtures/sg-${fixture}`), JSON.stringify(res, null, 4));
+            }
+        }
+    });
+});
+
+test.skip('drop good-run database', (t) => {
     let pool = new pg.Pool({
         max: 10,
         user: 'postgres',
-        database: 'pt_test_good',
+        database: 'pt_test',
         idleTimeoutMillis: 30000
     });
 

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -59,7 +59,7 @@ test('map - cardinal clustering', (t) => {
 
         rl.on('line', (line) => {
             if (!line) return;
-            console.log('ok - line:', line);
+            console.log('ok - cp line:', line);
         });
 
         rl.on('error', t.error);


### PR DESCRIPTION
Builds test for #215 

- [x] creates sample `address` and `network` geojson with slight cardinality differences that `FreeRadicals` should fix
- [x] adds stub test that runs ^ through `map.js`
- [ ] actually test for something

The first pass at a test had a couple problems; the test would either hang or error out, apparently at random. 

- [x] tidy up how we track child processes, to make sure they're being closed properly
    - [x] don't increment the `length` property of an array
    - [x] check the `killed` property of a child process directly rather than relying on a separately `active` property

- [x] don't write empty lines from `split` child processes, which was causing a `write after end` error

We worked through the errors, but the test is still failing to end as expected.