### PR TITLE
add nyc code coverage integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,6 @@ jobs:
                 name: "yarn run coverage"
                 command: "yarn run coverage"
                 no_output_timeout: 12000
+            - run:
+                name: "yarn run coverage-upload"
+                command: "yarn run coverage-upload"

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -283,7 +283,7 @@ class Cluster {
 
     /**
     * Collapse together duplicate network_clusters
-    * @param {Function} callback Callback func (err, res)
+    * @param {Function} cb Callback func (err, res)
     * @return {Function} callback
     **/
     collapse(cb) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "coveralls": "^3.0.0",
     "documentation": "^5.3.1",
     "eslint": "^4.6.1",
-    "istanbul": "^0.4.0",
+    "nyc": "^11.3.0",
     "tape": "^4.7.0",
     "tmp": "0.0.33"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "lint": "eslint index.js test/* lib/*",
-    "coverage": "istanbul cover tape test/*.js && coveralls < ./coverage/lcov.info",
+    "coverage": "nyc tape test/*.js && nyc report --reporter=text-lcov > coverage.lcov",
+    "coverage-upload": "coveralls < ./coverage.lcov",
     "doc": "./node_modules/documentation/bin/documentation.js lint ./lib/**",
     "test": "tape test/*.test.js",
     "pretest": "echo 'DROP DATABASE pt_test; CREATE DATABASE pt_test;' | psql postgres://postgres:@localhost:5432 && echo 'CREATE EXTENSION postgis;' | psql postgres://postgres:@localhost:5432/pt_test"


### PR DESCRIPTION
per request from @yhahn. goal is to ensure child processes are captured by coverage metric.

also fixes a jsdoc error that was preventing tests from passing.

cc @ingalls @KaiBot3000 @lizziegooding 