### PR TITLE
check for orphans with entirely ephemeral points

### DIFF
--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -90,12 +90,14 @@ class Orphan {
                                 feat.geometry.geometries[0].coordinates.push(coord);
                             });
 
-                            feat.properties['carmen:center'] = turf.pointOnSurface(feat.geometry.geometries[0]).geometry.coordinates;
-                            feat.properties['carmen:addressnumber'] = [ feat.properties['carmen:addressnumber'] ];
+                            if (feat.geometry.geometries[0].length) {
+                                feat.properties['carmen:center'] = turf.pointOnSurface(feat.geometry.geometries[0]).geometry.coordinates;
+                                feat.properties['carmen:addressnumber'] = [ feat.properties['carmen:addressnumber'] ];
 
-                            if (self.opts.country) feat.properties['carmen:geocoder_stack'] = self.opts.country;
+                                if (self.opts.country) feat.properties['carmen:geocoder_stack'] = self.opts.country;
 
-                            self.output.write(JSON.stringify(self.post.feat(feat)) + '\n');
+                                self.output.write(JSON.stringify(self.post.feat(feat)) + '\n');
+                            }
                         });
 
                         return iterate();


### PR DESCRIPTION
If orphan clusters are made entirely of ephemeral points, they'll end up with no geometry. That caused an error when we tried to use turf on a feature:
```
ok - clustered orphan addresses
/Users/kai/src/pt2itp/node_modules/@turf/helpers/index.js:90
    if (!isNumber(coordinates[0]) || !isNumber(coordinates[1])) throw new Error('Coordinates must contain numbers');
                                                                ^

Error: Coordinates must contain numbers
    at point (/Users/kai/src/pt2itp/node_modules/@turf/helpers/index.js:90:71)
    at module.exports (/Users/kai/src/pt2itp/node_modules/@turf/center/index.js:29:12)
    at Object.pointOnSurface (/Users/kai/src/pt2itp/node_modules/@turf/point-on-surface/index.js:39:16)
    at rows.forEach (/Users/kai/src/pt2itp/lib/orphan.js:93:69)
    at Array.forEach (native)
    at cursor.read (/Users/kai/src/pt2itp/lib/orphan.js:63:30)
    at Immediate.setImmediate (/Users/kai/src/pt2itp/node_modules/pg-cursor/index.js:86:7)
    at runCallback (timers.js:666:20)
    at tryOnImmediate (timers.js:639:5)
    at processImmediate [as _immediateCallback] (timers.js:611:5)
```

Fix:
- [x] add a check for features lacking geometry