### PR TITLE
check for nonemptiness of 'other' val

### DIFF
--- a/lib/label/titlecase.js
+++ b/lib/label/titlecase.js
@@ -84,6 +84,8 @@ module.exports = (opts) => {
         if (other) other = other.trim();
 
         if (!text) {
+            // if neither is truthy we are in trouble and need to bail
+            if (!other) return '';
             text = other;
         } else {
             // shortcircuit if network & address text agree


### PR DESCRIPTION
Getting an error on `titlecase` when processing some WY data. I think that when both the primary text and the alternate text are empty/undefined, a runtime error was thrown. This change checks for that condition and returns an empty string in the rare cases where it occurs. Downstream processing should suppress the use of an empty-label feature.