### PR TITLE
Add libstdc++-5-dev dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: ubuntu/16.04
+            - image: ubuntu:16.04
             - image: mdillon/postgis:9.6
               environment:
                 - POSTGRES_USER=postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                 command: "apt-get update -y && apt-get install -y curl"
             - run:
                 name: "Install node with nvm"
-                command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && nvm install 6.10.3"
+                command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
                 command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
             - run:
                 name: "Update APT Cache & Install latest yarn"
                 command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client"
+            - run:
+                name: "Update APT Cache & Insall libstdc++ v5"
+                command: "sudo apt-get -y update && sudo apt-get install libstdc++-5-dev"
 
             - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                 command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
-                command: "apt-get install software-properties-common && apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list"
+                command: "apt-get install -y software-properties-common && apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list"
             - run:
                 name: "Update APT Cache & Install latest yarn & libstdc++-5-dev"
                 command: "apt-get -y update && apt-get install -y yarn postgresql-client && apt-get -y install libstdc++-5-dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                 command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
-                command: "apt-get install -y software-properties-common && apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list"
+                command: "apt-get install -y software-properties-common git && apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list"
             - run:
                 name: "Update APT Cache & Install latest yarn & libstdc++-5-dev"
                 command: "apt-get -y update && apt-get install -y yarn postgresql-client && apt-get -y install libstdc++-5-dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,20 @@ jobs:
 
             - run:
                 name: "yarn install"
-                command: "source ~/.bashrc && yarn install"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn install"
             - run:
                 name: "yarn lint"
-                command: "source ~/.bashrc && yarn run lint"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn run lint"
             - run:
                 name: "yarn doc"
-                command: "source ~/.bashrc && yarn run doc"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn run doc"
             - run:
                 name: "yarn pretest"
-                command: "source ~/.bashrc && yarn run pretest"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn run pretest"
             - run:
                 name: "yarn run coverage"
-                command: "source ~/.bashrc && yarn run coverage"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn run coverage"
                 no_output_timeout: 12000
             - run:
                 name: "yarn run coverage-upload"
-                command: "source ~/.bashrc && yarn run coverage-upload"
+                command: "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && yarn run coverage-upload"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,20 @@ jobs:
 
             - run:
                 name: "yarn install"
-                command: "yarn install"
+                command: "source ~/.bashrc && yarn install"
             - run:
                 name: "yarn lint"
-                command: "yarn run lint"
+                command: "source ~/.bashrc && yarn run lint"
             - run:
                 name: "yarn doc"
-                command: "yarn run doc"
+                command: "source ~/.bashrc && yarn run doc"
             - run:
                 name: "yarn pretest"
-                command: "yarn run pretest"
+                command: "source ~/.bashrc && yarn run pretest"
             - run:
                 name: "yarn run coverage"
-                command: "yarn run coverage"
+                command: "source ~/.bashrc && yarn run coverage"
                 no_output_timeout: 12000
             - run:
                 name: "yarn run coverage-upload"
-                command: "yarn run coverage-upload"
+                command: "source ~/.bashrc && yarn run coverage-upload"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                 command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client"
             - run:
                 name: "Add Ubuntu Toolchain PPA, update APT cache, & install libstdc++ v5"
-                command: "sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -y update && sudo apt-get -y install libstdc++-5-dev"
+                command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -y update && sudo apt-get -y install libstdc++-5-dev"
 
             - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,16 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/node:6.10.3
+            - image: ubuntu/16.04
             - image: mdillon/postgis:9.6
               environment:
                 - POSTGRES_USER=postgres
                 - POSTGRES_DB=pt_test
 
         steps:
+            - run:
+                name: "Install node with nvm"
+                command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
                 command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ jobs:
                 command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
-                command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"
+                command: "apt-get install software-properties-common && apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list"
             - run:
                 name: "Update APT Cache & Install latest yarn & libstdc++-5-dev"
-                command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client && sudo apt-get -y install libstdc++-5-dev"
+                command: "apt-get -y update && apt-get install -y yarn postgresql-client && apt-get -y install libstdc++-5-dev"
 
             - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,11 @@ jobs:
 
         steps:
             - run:
-                name: "Install Yarn PPAs"
-                command: "curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"
+                name: "Install Yarn & Ubuntu Toolchain PPAs"
+                command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"
             - run:
-                name: "Update APT Cache & Install latest yarn"
-                command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client"
-            - run:
-                name: "Add Ubuntu Toolchain PPA, update APT cache, & install libstdc++ v5"
-                command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -y update && sudo apt-get -y install libstdc++-5-dev"
+                name: "Update APT Cache & Install latest yarn & libstdc++-5-dev"
+                command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client && sudo apt-get -y install libstdc++-5-dev"
 
             - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                 command: "apt-get update -y && apt-get install -y curl"
             - run:
                 name: "Install node with nvm"
-                command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && nvm install 6.10.3"
+                command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install 6.10.3"
             - run:
                 name: "Install Yarn & Ubuntu Toolchain PPAs"
                 command: "sudo apt-get install software-properties-common && sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
 
         steps:
             - run:
+                name: "Install cURL"
+                command: "apt-get update -y && apt-get install -y curl"
+            - run:
                 name: "Install node with nvm"
                 command: "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash && nvm install 6.10.3"
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
                 name: "Update APT Cache & Install latest yarn"
                 command: "sudo apt-get -y update && sudo apt-get install -y yarn postgresql-client"
             - run:
-                name: "Update APT Cache & Insall libstdc++ v5"
-                command: "sudo apt-get -y update && sudo apt-get install libstdc++-5-dev"
+                name: "Add Ubuntu Toolchain PPA, update APT cache, & install libstdc++ v5"
+                command: "sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -y update && sudo apt-get -y install libstdc++-5-dev"
 
             - checkout
 


### PR DESCRIPTION
Per https://github.com/ingalls/pt2itp/pull/219#issuecomment-346494331 adds the `libstdc++-5-dev` dependency to circle config. Circle tests for https://github.com/ingalls/pt2itp/pull/219 and https://github.com/ingalls/pt2itp/pull/233 were failing due to this missing dependency.

cc @mattficke  @ingalls 