### PR TITLE
remove pretensions to multilingual capitalization support

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -22,7 +22,7 @@ class Cluster {
         if (opts.label)
             this.label = require('./label/' + opts.label)();
         else
-            this.label = require('./label/titlecase')({ language: 'en' });
+            this.label = require('./label/titlecase')();
     }
 
     /**

--- a/lib/label/titlecase.js
+++ b/lib/label/titlecase.js
@@ -56,12 +56,9 @@ function titleCase(text, config) {
 module.exports = (opts) => {
     opts = opts || {};
 
-    let titleCaseConfig;
-    if (opts.language && (opts.language !== 'en')) {
-        throw new Error('only en titlecase minors are currently supported');
-    } else {
-        titleCaseConfig = require('@mapbox/title-case')(opts.language);
-    }
+    // for the time being we only use en rules -- supporting culturally correct capitalization
+    // conventions is an effort that has to span layers beyond just address
+    let titleCaseConfig = require('@mapbox/title-case')('en');
 
     let synonym = !!opts.synonym;
 

--- a/lib/map.js
+++ b/lib/map.js
@@ -422,7 +422,7 @@ function main(argv, cb) {
                     };
                     if (argv.label) opts.label = argv.label;
                     if (!argv.label && argv.tokens && (argv.tokens.indexOf('en') === -1))
-                        console.error('WARN: map.split() using titlecase behavior, which is currently English-only, on non-English data');
+                        console.error('WARN: map.split() using titlecase behavior on non-English data; English capitalization rules will be applied, potentially in error');
                     child.send(opts);
                 }
             });

--- a/lib/orphan.js
+++ b/lib/orphan.js
@@ -13,15 +13,10 @@ class Orphan {
         this.output = output;
         this.post = post;
 
-        if (!opts.label && opts.tokens && (opts.tokens.indexOf('en') === -1)) {
-            console.error('WARN: map.orphanAddr() using titlecase behavior, which is current English-only, on non-English data');
-        }
+        if (!opts.label && opts.tokens && (opts.tokens.indexOf('en') === -1))
+            console.error('WARN: map.orphanAddr() using titlecase behavior on non-English data; English capitalization rules will be applied, potentially in error');
 
-        if (!opts.label) {
-            this.label = require('./label/titlecase')({ language: 'en' });
-        } else {
-            this.label = require('./label/' + opts.label)();
-        }
+        this.label = require('./label/' + (opts.label || 'titlecase'))();
     }
 
     /**

--- a/lib/split.js
+++ b/lib/split.js
@@ -79,11 +79,7 @@ function init(o) {
 
     cluster = new Cluster({ pool: pool });
 
-    if (!opts.label) {
-        label = require('./label/titlecase')({ language: 'en', synonym: true });
-    } else {
-        label = require('./label/' + opts.label)({ language: opts.tokens.join(',') || 'en', synonym: true });
-    }
+    label = require('./label/' + (opts.label || 'titlecase'))({ synonym: true });
 
     return true;
 }

--- a/test/titlecase.test.js
+++ b/test/titlecase.test.js
@@ -32,7 +32,7 @@ tape('title case xformation', (t) => {
 });
 
 tape('label logic, default behavior', (t) => {
-    const label = require('../lib/label/titlecase')({ language: 'en' });
+    const label = require('../lib/label/titlecase')();
     let tests = [
         [{ address_text: 'our lady of whatever', network_text: 'our lady' }, 'Our Lady of Whatever'],
         [{ address_text: 'our lady of whatever', network_text: 'OUR LADY of WHATEVER' }, 'OUR LADY of WHATEVER'],
@@ -46,7 +46,7 @@ tape('label logic, default behavior', (t) => {
 });
 
 tape('label logic, favor network', (t) => {
-    const label = require('../lib/label/titlecase')({ language: 'en', favor: 'network' });
+    const label = require('../lib/label/titlecase')({ favor: 'network' });
     let tests = [
         [{ address_text: 'our lady of whatever', network_text: 'our lady ' }, 'Our Lady']
     ];
@@ -58,7 +58,7 @@ tape('label logic, favor network', (t) => {
 });
 
 tape('label logic, include synonyms', (t) => {
-    const label = require('../lib/label/titlecase')({ language: 'en', synonym: true});
+    const label = require('../lib/label/titlecase')({ synonym: true });
     let tests = [
         [{ address_text: 'our lady of whatever', network_text: 'our lady ' }, 'Our Lady of Whatever,Our Lady']
     ];


### PR DESCRIPTION
Automatic titlecasing behavior kicks in when we don't detect adequate capitalization signals from either the network or address data. This should occur rarely. When it does, we have been using English title-case behavior: capitalizing every word except a blacklist of prepositions and articles. Although English rules were always used, code paths had been stubbed out to allow non-English support in the future.

Some research shows that the dominant non-English pattern for capitalization is "first letter plus proper nouns" (with some variations around adjectival forms of proper nouns). Detection of proper nouns is difficult, as is making sure the capitalized address data meshes with other data in the geocoding response (which probably includes city names, etc).

Tackling support for non-English capitalization rules is therefore a big quest and one that's out of scope for right now. This PR removes some of the interface elements that might lead users to incorrectly think that non-English capitalization rules are supported. The hardcoding to English is made more explicit in `titlecase.js`.