### PR TITLE
Avoid Excessive Tokens

### DIFF
--- a/lib/post/dedupe-text.js
+++ b/lib/post/dedupe-text.js
@@ -1,9 +1,9 @@
 const tokenize = require('../tokenize');
 const tokens = require('@mapbox/geocoder-abbreviations');
 
-
 /**
  * Exposes a post function to dedupe synonyms on features
+ * And also ensure that synonyms do not exceed the 10 Synonym limit
  * @param {Object} feat     GeoJSON Feature to dedupe
  * @return {Object}         Output GeoJSON feature to write to output
  */
@@ -43,7 +43,13 @@ function post(feat, opts) {
                 }
                 return prev;
             }, [])
-            .join(',');
+
+            if (feat.properties[k].length > 10) {
+                console.error(`ok - WARN too many synonyms - truncating!: {}`, feat.properties[k].join(','));
+                feat.properties[k] = feat.properties[k].splice(0, 10);
+            }
+
+            feat.properties[k] = feat.properties[k].join(',');
         });
 
     return feat;

--- a/test/post.dedupe-text.test.js
+++ b/test/post.dedupe-text.test.js
@@ -64,5 +64,17 @@ test('Post: Dedupe', (t) => {
         }
     }, 'dedupe tokens, multi language');
 
+    t.deepEquals(post({
+        properties: {
+            'carmen:text': '204 Haywood Rd,201 Haywood Rd,202 Haywood Rd,203 Haywood Rd,208 Haywood Rd,209 Haywood Rd,210 Haywood Rd,211 Haywood Rd,212 Haywood Rd,213 Haywood Rd,214 Haywood Rd,215 Haywood Rd,216 Haywood Rd,217 Haywood Rd,218 Haywood Rd',
+            'carmen:text_xx': '204 Haywood Rd,201 Haywood Rd,202 Haywood Rd,203 Haywood Rd,208 Haywood Rd,209 Haywood Rd,210 Haywood Rd,211 Haywood Rd,212 Haywood Rd,213 Haywood Rd,214 Haywood Rd,215 Haywood Rd,216 Haywood Rd,217 Haywood Rd,218 Haywood Rd'
+        }
+    }, { tokens: ['en', 'es'] }), {
+        properties: {
+            'carmen:text': '204 Haywood Rd,201 Haywood Rd,202 Haywood Rd,203 Haywood Rd,208 Haywood Rd,209 Haywood Rd,210 Haywood Rd,211 Haywood Rd,212 Haywood Rd,213 Haywood Rd',
+            'carmen:text_xx': '204 Haywood Rd,201 Haywood Rd,202 Haywood Rd,203 Haywood Rd,208 Haywood Rd,209 Haywood Rd,210 Haywood Rd,211 Haywood Rd,212 Haywood Rd,213 Haywood Rd'
+        }
+    }, 'dedupe tokens, excessive synonyms');
+
     t.end();
 });


### PR DESCRIPTION
Thanks to some awesome debugging @apendleton identified a huge perf. bug in carmen-indexer where in cases where OpenAddress data wasn't property segmented we would have 10+ synonyms for each address in the text field.

This now warns and truncates when there are more than 10 synonyms with the intent of the user going upstream to the OA source to fix the parsing logic.
