### PR TITLE
Numbers Aren't Cheap

### DIFF
--- a/lib/linker.js
+++ b/lib/linker.js
@@ -15,6 +15,9 @@ function linker(addr, nets, returnAll) {
     eqNets = nets.filter((n) => { return n.text === addr.text; });
     if (eqNets.length) return eqNets;
 
+    //Handle Numered Streets (ie: 11th should never match 12th)
+    addr.isNumbered = isNumbered(addr.text);
+
     for (let net_it = 0; net_it < nets.length; net_it++) {
         let net = nets[net_it];
 
@@ -22,6 +25,10 @@ function linker(addr, nets, returnAll) {
         // this might require adjustment for countries with addresses that have leading tokens which aren't properly stripped
         // from the token list
         if (net.text_tokenless && addr.text_tokenless && (net.text_tokenless[0] !== addr.text_tokenless[0])) continue;
+
+        let netNumber = isNumbered(net.text);
+        //Dont bother considering if both addr and network are a numbered street that don't match (1st != 11th)
+        if (addr.isNumbered && addr.isNumbered !== netNumber) continue;
 
         // use a weighted average w/ the tokenless dist score if possible
         let levScore;
@@ -70,4 +77,30 @@ function linker(addr, nets, returnAll) {
     }
 }
 
+/**
+ * Is the street a numered type street ie: 1st 2nd 3rd etc
+ * @param {string} text Text to test against
+ * @return {boolean|string}
+ */
+function isNumbered(text) {
+    let toks = text.split(' ');
+
+    let tests = [
+        /^(([0-9]+)?1st)$/,
+        /^(([0-9]+)?2nd)$/,
+        /^(([0-9]+)?3rd)$/,
+        /^([0-9]+th)$/,
+    ]
+
+    for (let tok of toks) {
+        for (let t of tests) {
+            let m = tok.match(t);
+            if (m) return m[0]
+        }
+    }
+
+    return false;
+}
+
 module.exports = linker;
+module.exports.isNumbered = isNumbered;

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -1,6 +1,21 @@
 const linker = require('../lib/linker');
 const test = require('tape');
 
+test('linker#isNumbered', (t) => {
+
+    t.equals(linker.isNumbered('main st'), false, 'main st => false');
+    t.equals(linker.isNumbered('1st st'), '1st', '1st st => 1st');
+    t.equals(linker.isNumbered('2nd st'), '2nd', '2nd st => 2nd');
+    t.equals(linker.isNumbered('west 2nd st'), '2nd', 'west 2nd st => 2nd');
+    t.equals(linker.isNumbered('3rd st'), '3rd', '3rd st = 3rd');
+    t.equals(linker.isNumbered('4th av'), '4th', '4th av => 4th');
+    t.equals(linker.isNumbered('21st av'), '21st', '21st av => 21st');
+    t.equals(linker.isNumbered('32nd av'), '32nd', '32nd av => 32nd');
+    t.equals(linker.isNumbered('45th av'), '45th', '45th av => 45th');
+    t.equals(linker.isNumbered('351235th av'), '351235th', '351235th av => 351235th');
+    t.end();
+});
+
 test('Passing Linker Matches', (t) => {
     t.deepEquals(
         linker({ text: 'main st' }, [
@@ -15,6 +30,41 @@ test('Passing Linker Matches', (t) => {
         ]),
         [{ id: 1, text: 'maim st', score: 85.71428571428572 }],
     'close match');
+
+    t.deepEquals(
+        linker({ text: '1st st west' }, [
+            { id: 1, text: '2nd st west' },
+        ]),
+        false,
+    'no match numeric simple (2nd)');
+    
+    t.deepEquals(
+        linker({ text: '1st st west' }, [
+            { id: 1, text: '3rd st west' },
+        ]),
+        false,
+    'no match numeric simple (3rd)');
+
+    t.deepEquals(
+        linker({ text: '1st st west' }, [
+            { id: 1, text: '4th st west' },
+        ]),
+        false,
+    'no match numeric simple (4th)');
+
+    t.deepEquals(
+        linker({ text: '11th st west' }, [
+            { id: 1, text: '21st st west' },
+        ]),
+        false,
+    'no match numeric simple (21st)');
+
+    t.deepEquals(
+        linker({ text: '11th st west' }, [
+            { id: 1, text: '11th av west' },
+        ]),
+        [ { id: 1, text: '11th av west', score: 83.33333333333334 } ],
+    'match numeric simple (type mismatch)');
 
     t.deepEquals(
         linker({ text: 'main st' }, [

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -37,7 +37,7 @@ test('Passing Linker Matches', (t) => {
         ]),
         false,
     'no match numeric simple (2nd)');
-    
+
     t.deepEquals(
         linker({ text: '1st st west' }, [
             { id: 1, text: '3rd st west' },


### PR DESCRIPTION
Something that is coming up a lot is that the linker will link textually similiar addresses to a single network where they are numbered streets.

IE: `24th st w`, `25th st w`,`26th st w` matched with `36th st west`

This special cases numbered streets as textual similiarity is not important, exact matches of the numbered portion are.

So `24th ST` can still match `24th Av` but `24th St W` cannot match `34th St W` ever. These unmatched addresses will now just be orphaned.