### PR TITLE
Drop address cluster from combined ITP + address feature

### DIFF
--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -445,6 +445,8 @@ function join(itps, argv) {
         }
     }
 
+    // If the combined address feature doesn't contain an address cluster (the interpolated line didn't match any addresses), remove the empty address cluster properties and geometries
+
     if (itp.properties['carmen:addressnumber'][1].length === 0) {
         delete itp.properties['carmen:addressnumber'];
         ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {

--- a/lib/interpolize.js
+++ b/lib/interpolize.js
@@ -445,6 +445,14 @@ function join(itps, argv) {
         }
     }
 
+    if (itp.properties['carmen:addressnumber'][1].length === 0) {
+        delete itp.properties['carmen:addressnumber'];
+        ['carmen:parityl', 'carmen:lfromhn', 'carmen:ltohn', 'carmen:parityr', 'carmen:rfromhn', 'carmen:rtohn'].forEach((prop) => {
+            itp.properties[prop].pop();
+        });
+        itp.geometry.geometries.pop();
+    }
+
     return argv.post.feat(itp);
 }
 

--- a/test/fixtures/left-hook-network.json
+++ b/test/fixtures/left-hook-network.json
@@ -1,0 +1,65 @@
+{
+  "type": "Feature",
+  "properties": {
+    "carmen:text": "Tommy Bell Pl",
+    "carmen:rangetype": "tiger",
+    "carmen:parityl": [
+      [
+        null
+      ]
+    ],
+    "carmen:lfromhn": [
+      [
+        null
+      ]
+    ],
+    "carmen:ltohn": [
+      [
+        null
+      ]
+    ],
+    "carmen:parityr": [
+      [
+        null
+      ]
+    ],
+    "carmen:rfromhn": [
+      [
+        null
+      ]
+    ],
+    "carmen:rtohn": [
+      [
+        null
+      ]
+    ],
+    "carmen:center": [
+      -77.19209790229797,
+      39.09155388949448
+    ]
+  },
+  "geometry": {
+    "type": "GeometryCollection",
+    "geometries": [
+      {
+        "type": "MultiLineString",
+        "coordinates": [
+          [
+            [
+              -77.19249486923218,
+              39.090421398604306
+            ],
+            [
+              -77.19209790229797,
+              39.09155388949448
+            ],
+            [
+              -77.19150245189667,
+              39.091428983303274
+            ]
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/test/interpolize.test.js
+++ b/test/interpolize.test.js
@@ -641,3 +641,30 @@ test('Interpolize - Hooked Road', (t) => {
     t.end();
 });
 
+test('Interpolize - No address cluster', (t) => {
+    let segs = [{
+        network: {
+            type: "Feature",
+            properties: { },
+            geometry: {
+                type: "LineString",
+                coordinates: [
+                    [ -77.19249486923218, 39.090421398604306 ],
+                    [ -77.19209790229797, 39.09155388949448 ],
+                    [ -77.19150245189667, 39.091428983303274 ]
+                ]
+            }
+        }
+    }];
+
+    let res = interpolize('Tommy Bell Pl', segs);
+    delete res.id;
+
+    if (process.env.UPDATE) {
+        fs.writeFileSync(__dirname + '/fixtures/left-hook-network.json', JSON.stringify(res, null, 4));
+        t.fail('had to update fixture');
+    }
+
+    t.deepEquals(res, require('./fixtures/left-hook-network.json'));
+    t.end();
+});


### PR DESCRIPTION
I found that after including interpolated line data in a source, turf started throwing the following error:

```
    if (!isNumber(coordinates[0]) || !isNumber(coordinates[1])) throw new Error('Coordinates must contain numbers');
                                                                ^

Error: Coordinates must contain numbers
```

It looks like these errors are being thrown for interpolated line networks which aren't matched to any address clusters. Rather than removing these properties and geometries from the ITP + address feature, they're being left empty, resulting in geometry collections that look like:
```
{
    "type": "GeometryCollection",
    "geometries": [
      {
        "type": "MultiLineString",
        "coordinates": [
           "coordinates": [
          [
            [
              -77.19249486923218,
              39.090421398604306
            ],
            [
              -77.19209790229797,
              39.09155388949448
            ],
            [
              -77.19150245189667,
              39.091428983303274
            ]
          ]
        ]
      },
      {
        "type": "MultiPoint",
        "coordinates": [] // no coordinates here :(
      }
    ]
  }
```
To fix this, I removed the empty address cluster properties and geometries if the final interpolated feature doesn't any address number values.

@ingalls mind reviewing? 
