### PR TITLE
improve handling of unnamed/bad network segments

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -256,6 +256,7 @@ class Cluster {
                         MAX(text_tokenless) AS text_tokenless,
                         unnest(ST_ClusterWithin(geom, 0.005)) AS geom
                     FROM network
+                    WHERE _text != ''
                     GROUP BY text
                 ) netw;
 

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -90,7 +90,7 @@ function map(feat, context) {
                 for (i=0; i < preprocessSteps.length; i++) {
                     n = preprocessSteps[i](n);
                 }
-                names.push(n);
+                if (n) names.push(n);
             }
         }
     }


### PR DESCRIPTION
I encountered gigantic webs of unnamed roads in rural Saskatchewan that brought my machine to its knees. This is the result of uselessly unnamed roads being included in the `network_cluster` table, creating a huge feature than encompasses virtually everything.

This PR fixes this by:
- perform network clustering only on named segments

It also does the following, which didn't turn out to be the problem but is a potential bug that I spotted along the way. Without this modification a bunch of `undefined`s can be added to a feature's name array.
- allows process script early returns to avoid adding name data

cc @ingalls @aarthykc @KaiBot3000 @aaaandrea @boblannon @lizziegooding 