### PR TITLE
Change context of csvStream.resume

### DIFF
--- a/lib/testcsv.js
+++ b/lib/testcsv.js
@@ -130,7 +130,7 @@ function test(argv, cb) {
         * Loop through a given buffer and geocode each address with carmen
         * @param {Object} buffer containing <= 25 lines of the input CSV where each
         * line is an address
-        * @param {Function} cb
+        * @param {Function} callback
         * @return {Function} cb
         */
         function geocodeBuffer(buffer, callback) {

--- a/lib/testcsv.js
+++ b/lib/testcsv.js
@@ -112,8 +112,7 @@ function test(argv, cb) {
 
             if (buffer.length >= 25) {
                 csvStream.pause();
-                buffer.push(data);
-                geocodeBuffer(buffer, csvStream.resume);
+                geocodeBuffer(buffer, () => csvStream.resume());
             } else {
                 buffer.push(data);
             }
@@ -134,7 +133,7 @@ function test(argv, cb) {
         * @param {Function} cb
         * @return {Function} cb
         */
-        function geocodeBuffer(buffer, cb) {
+        function geocodeBuffer(buffer, callback) {
             let addrQ = new Q();
 
             for (let entry of buffer) {
@@ -159,10 +158,9 @@ function test(argv, cb) {
 
                 for (let r of res) {
                     if (!r) continue;
-
                     logResult(r[0], r[1]);
                 }
-                cb();
+                callback();
             });
         }
 

--- a/lib/testcsv.js
+++ b/lib/testcsv.js
@@ -109,10 +109,13 @@ function test(argv, cb) {
 
         csvStream.on('data', (data) => {
             if (!isNumber(data[0]) || !isNumber(data[1])) return; // don't process rows with bad coords
-
             if (buffer.length >= 25) {
                 csvStream.pause();
-                geocodeBuffer(buffer, () => csvStream.resume());
+                buffer.push(data);
+                geocodeBuffer(buffer, () => {
+                    buffer = [];
+                    csvStream.resume();
+                });
             } else {
                 buffer.push(data);
             }
@@ -153,8 +156,6 @@ function test(argv, cb) {
 
             addrQ.awaitAll((err, res) => {
                 if (err) return cb(err);
-
-                buffer = [];
 
                 for (let r of res) {
                     if (!r) continue;


### PR DESCRIPTION
Testcsv mode has been failing with the following error:
```
_stream_readable.js:718
  var state = this._readableState;
                  ^

TypeError: Cannot read property '_readableState' of undefined
    at Readable.resume (_stream_readable.js:718:19)
    at Queue.addrQ.awaitAll [as _call] (/Users/lizziegooding/pt2itp/lib/testcsv.js:170:26)
    at maybeNotify (/Users/lizziegooding/pt2itp/node_modules/d3-queue/build/d3-queue.js:120:7)
    at /Users/lizziegooding/pt2itp/node_modules/d3-queue/build/d3-queue.js:91:12
    at Function.isPass (/Users/lizziegooding/pt2itp/lib/geocode.js:70:12)
    at c.geocode (/Users/lizziegooding/pt2itp/lib/testcsv.js:150:33)
    at finalize (/Users/lizziegooding/pt2itp/node_modules/@mapbox/carmen/lib/geocode.js:396:16)
    at Queue._call (/Users/lizziegooding/pt2itp/node_modules/@mapbox/carmen/lib/verifymatch.js:209:9)
    at maybeNotify (/Users/lizziegooding/pt2itp/node_modules/d3-queue/build/d3-queue.js:120:7)
    at Queue.awaitAll (/Users/lizziegooding/pt2itp/node_modules/d3-queue/build/d3-queue.js:51:5)
```
This was introduced in https://github.com/ingalls/pt2itp/pull/264/files when the geocodeBuffer function was created to move functionality outside of the csv parsing function. The issue is that when `csvStream.resume` is called within the d3.queue it has an undefined context (`this`) and therefore errs out. Passing`csvStream.resume` as an argument in an anonymous function fixes this. 