### PR TITLE
Successful pass

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -18,8 +18,10 @@ const tokenize = require('./tokenize').main;
  * @param {function} done Callback fxn
  * @return {function}
  */
-function isPass(query, pt, res, opts, done) {
+function isPass(query, pt, res, opts = {}, done) {
     let cleanQuery = tokenize(diacritics(query), opts.tokens);
+
+    if (!opts.stats) opts.stats = {}
 
     if (!res.features.length) {
         if (opts.stats) opts.stats.fail++;
@@ -42,7 +44,7 @@ function isPass(query, pt, res, opts, done) {
     if (opts.stats.itp && res.features[0].geometry.interpolated)
         opts.stats.itp.total += 1;
 
-    if (matchedCount / matched.length < 0.70) {
+    if (matchedCount / cleanQuery.length < 0.70) {
         if (opts.stats) opts.stats.fail++;
         return done(null, ['TEXT', { query: cleanQuery.join(' '), queryPoint: pt.join(','), addressText: matched.join(' ') }]);
     } else if (dist && dist > 1 && !res.features[0].geometry.interpolated) {

--- a/test/geocode.test.js
+++ b/test/geocode.test.js
@@ -1,0 +1,37 @@
+const test = require('tape');
+
+const geocode = require('../lib/geocode');
+const tokens = require('../lib/tokenize');
+
+test('geocode#isPass', (t) => {
+    let query = [
+        '200 Broadway',
+        [-71.308992,41.495267],
+        {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                place_name: '200 Broadway St',
+                properties: {},
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-71.308992,41.495267]
+                }
+            }]
+        }, {
+            tokens: tokens.createReplacer(['en'])
+        },
+        function(err, res) {
+            t.error(err)
+
+            console.error(res);
+
+            t.equals(res);
+
+            t.end();
+        }
+    ]
+
+    geocode.isPass(...query);
+
+});


### PR DESCRIPTION
- Use number of cleanQuery tokens as pass metric.
- Add first tests around `lib/geocode`