### PR TITLE
faster query for totalDiffNames

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -297,8 +297,13 @@ function test(argv, cb) {
                 }
 
                 console.error('ok - beginning diff name');
-                client.query(`SELECT count(*) FROM address a, network_cluster n WHERE netid IS NOT NULL AND a._text != any(regexp_split_to_array(n._text, \',\'));
-                SELECT count(*) FROM address;`, (err, res) => {
+                client.query(`
+                    SELECT COUNT(*) FROM
+                        (SELECT * FROM address a WHERE netid IS NOT NULL) a
+                        WHERE a._text NOT IN
+                        (SELECT DISTINCT(UNNEST(REGEXP_SPLIT_TO_ARRAY(n._text, ','))) AS uniqtext FROM network_cluster n);
+                    SELECT count(*) FROM address;
+                `, (err, res) => {
                     if (err) return cb(err);
 
                     let totalDiffNames = res[0].rows[0].count;


### PR DESCRIPTION
The query for the total number of address names that didn't match anything in the network table is pretty beastly atm.

```
mbpl_gb_address_both=# EXPLAIN SELECT count(*) FROM address a, network_cluster n WHERE netid IS NOT NULL AND a._text != any(regexp_split_to_array(n._text, ','));
                                       QUERY PLAN
----------------------------------------------------------------------------------------
 Aggregate  (cost=837187273374.46..837187273374.47 rows=1 width=8)
   ->  Nested Loop  (cost=0.00..780368712545.50 rows=22727424331584 width=0)
         Join Filter: (a._text <> ANY (regexp_split_to_array(n._text, ','::text)))
         ->  Seq Scan on network_cluster n  (cost=0.00..54225.08 rows=900508 width=32)
         ->  Materialize  (cost=0.00..980094.98 rows=25238448 width=32)
               ->  Seq Scan on address a  (cost=0.00..681373.74 rows=25238448 width=32)
                     Filter: (netid IS NOT NULL)
```

This PR replaces it with a less expensive query that (I believe) does the same thing:

```
mbpl_gb_address_both=# EXPLAIN ANALYZE select count(*) from (SELECT * FROM address a where netid is not null) a where a._text not in (select distinct(unnest(regexp_split_to_array(n._text, ','))) as uniqtext from network_cluster n);
                                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=837465.88..837465.89 rows=1 width=8) (actual time=14901.853..14901.854 rows=1 loops=1)
   ->  Seq Scan on address a  (cost=61130.89..805917.82 rows=12619224 width=0) (actual time=2586.619..12453.564 rows=7908516 loops=1)
         Filter: ((netid IS NOT NULL) AND (NOT (hashed SubPlan 1)))
         Rows Removed by Filter: 17456758
         SubPlan 1
           ->  HashAggregate  (cost=60978.89..61080.89 rows=20000 width=32) (actual time=2161.109..2364.094 rows=401267 loops=1)
                 Group Key: unnest(regexp_split_to_array(n._text, ','::text))
                 ->  Seq Scan on network_cluster n  (cost=0.00..58727.62 rows=900508 width=32) (actual time=0.020..1566.088 rows=905662 loops=1)
 Planning time: 0.126 ms
 Execution time: 14901.909 ms
```