### PR TITLE
handle numeric suffixes; allow returned points through in TEXT errs

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -9,6 +9,8 @@ const diacritics = require('diacritics').remove;
 const turf = require('@turf/turf');
 const tokenize = require('./tokenize').main;
 
+var conf = {};
+
 /**
  * Return true or false if the query passed the matching criteria with the result
  * @param {string} query The query geocoded
@@ -31,6 +33,16 @@ function isPass(query, pt, res, opts = {}, done) {
     let name = res.features[0].matching_place_name ? res.features[0].matching_place_name : res.features[0].place_name;
     let matched = tokenize(diacritics(name), opts.tokens);
 
+    // normalize away numeric suffixes like 1st 2nd 3rd 4th in us/ca/gb
+    if (conf.geocoder_stack && ['au', 'ca', 'gb', 'nz', 'us'].some((cc) => { return conf.geocoder_stack.indexOf(cc) !== -1; })) {
+        function stripNumericSuffixes(t) {
+            let m = /(\d+)(st|nd|rd|th)/.exec(t);
+            return m ? m[1] : t;
+        }
+        cleanQuery = cleanQuery.map(stripNumericSuffixes);
+        matched = matched.map(stripNumericSuffixes);
+    }
+
     let dist = false;
     if (res.features[0].geometry.type === 'Point') {
         dist = turf.distance(res.features[0].geometry.coordinates, pt);
@@ -47,7 +59,7 @@ function isPass(query, pt, res, opts = {}, done) {
 
     if (matchedCount / cleanQuery.length < 0.70) {
         if (opts.stats) opts.stats.fail++;
-        return done(null, ['TEXT', { query: cleanQuery.join(' '), queryPoint: pt.join(','), addressText: matched.join(' ') }]);
+        return done(null, ['TEXT', { query: cleanQuery.join(' '), queryPoint: pt.join(','), addressText: matched.join(' '), returnedPoint: res.features[0].geometry.coordinates.join(',') }]);
     } else if (dist && dist > 1 && !res.features[0].geometry.interpolated) {
         if (opts.stats) opts.stats.fail++;
         if (opts.stats.dists) {
@@ -85,10 +97,14 @@ function localCarmen(param) {
         address: new MBTiles(path.resolve(param.index), () => {})
     };
 
-    if (param.getInfo.metadata) param.getInfo = param.getInfo.metadata; //Necessary for internal use
+    if (param.getInfo.metadata) {
+        if (param.getInfo.metadata.geocoder_stack)
+            conf.geocoder_stack = param.getInfo.metadata.geocoder_stack.slice(0);
+        param.getInfo = param.getInfo.metadata; //Necessary for internal use
+    }
 
     delete param.getInfo.tiles;
-    delete param.getInfo.geocdoer_data;
+    delete param.getInfo.geocoder_data;
     delete param.getInfo.geocoder_format;
 
     opts.address.getInfo = (cb) => {
@@ -163,3 +179,4 @@ function distReport(stats) {
 module.exports = localCarmen;
 module.exports.isPass = isPass;
 module.exports.distReport = distReport;
+module.exports.testConfig = function(config) { conf = config; };

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -179,4 +179,11 @@ function distReport(stats) {
 module.exports = localCarmen;
 module.exports.isPass = isPass;
 module.exports.distReport = distReport;
-module.exports.testConfig = function(config) { conf = config; };
+/**
+ * Test runner stub for setting geocoder_stack object
+ * @param {Object} config has the form { geocoder_stack: {Array} }
+ */
+function testConfig(config) {
+    conf = config;
+}
+module.exports.testConfig = testConfig;

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -12,6 +12,15 @@ const tokenize = require('./tokenize').main;
 var conf = {};
 
 /**
+ * Return the numeric portion of tokens like 1st, 2nd, 3rd; otherwise return token unaltered
+ * @param {string} t token
+**/
+function stripNumericSuffixes(t) {
+    let m = /(\d+)(st|nd|rd|th)/.exec(t);
+    return m ? m[1] : t;
+}
+
+/**
  * Return true or false if the query passed the matching criteria with the result
  * @param {string} query The query geocoded
  * @param {Array} pt an array of the format [lon,lat] representing the known coords of the query
@@ -35,10 +44,6 @@ function isPass(query, pt, res, opts = {}, done) {
 
     // normalize away numeric suffixes like 1st 2nd 3rd 4th in us/ca/gb
     if (conf.geocoder_stack && ['au', 'ca', 'gb', 'nz', 'us'].some((cc) => { return conf.geocoder_stack.indexOf(cc) !== -1; })) {
-        function stripNumericSuffixes(t) {
-            let m = /(\d+)(st|nd|rd|th)/.exec(t);
-            return m ? m[1] : t;
-        }
         cleanQuery = cleanQuery.map(stripNumericSuffixes);
         matched = matched.map(stripNumericSuffixes);
     }

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -73,7 +73,7 @@ function map(feat, context) {
             }
         }
 
-        if (['us', 'ca', 'gb'].indexOf(context.country) !== -1 && !highway) {
+        if (['au', 'ca', 'gb', 'nz', 'us'].indexOf(context.country) !== -1 && !highway) {
             let numericNameMatch = /^(\d+)(\s+\w.*)$/.exec(names[i].name);
 
             if (numericNameMatch) {

--- a/test/geocode-suffix.test.js
+++ b/test/geocode-suffix.test.js
@@ -1,0 +1,62 @@
+const test = require('tape');
+
+const geocode = require('../lib/geocode');
+const tokens = require('../lib/tokenize');
+
+test('geocode#isPass.suffix', (t) => {
+    geocode.testConfig({ geocoder_stack: ['us', 'xx'] });
+    let query = [
+        '200 101st Avenue',
+        [-71.308992,41.495267],
+        {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                place_name: '200 101 Ave',
+                properties: {},
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-71.308992,41.495267]
+                }
+            }]
+        }, {
+            tokens: tokens.createReplacer(['en'])
+        },
+        function(err, res) {
+            t.error(err)
+            t.notok(res);
+            t.end();
+        }
+    ]
+
+    geocode.isPass(...query);
+});
+
+test('geocode#isPass.suffix', (t) => {
+    geocode.testConfig({ geocoder_stack: ['fr'] });
+    let query = [
+        '200 101st Avenue',
+        [-71.308992,41.495267],
+        {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                place_name: '200 101 Ave',
+                properties: {},
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-71.308992,41.495267]
+                }
+            }]
+        }, {
+            tokens: tokens.createReplacer(['en'])
+        },
+        function(err, res) {
+            t.error(err)
+            t.deepEquals(res, [ 'TEXT', { query: '200 101st av', queryPoint: '-71.308992,41.495267', addressText: '200 101 av', returnedPoint: '-71.308992,41.495267' } ]);
+            t.end();
+        }
+    ]
+
+    geocode.isPass(...query);
+});


### PR DESCRIPTION
currently `TEXT` errors
- don't include returned points in the output logs
- fail to regard `101 Ave` and `101st Ave` as equivalent

This PR fixes that. It also expands the list of numeric suffix-using countries to include Australia and New Zealand.