### PR TITLE
Skip autonaming by default [MAJOR VERSION]

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -49,7 +49,8 @@ function main(argv, cb) {
             boolean: [
                 'name',
                 'debug',
-                'skip-import'
+                'skip-import',
+                'autoname'
             ],
             alias: {
                 'in-address': 'in-addresses',
@@ -178,6 +179,11 @@ function main(argv, cb) {
     function nameNetwork(err) {
         if (err) throw err;
         console.error('ok - optimized data')
+
+        if (!argv.autoname) {
+            console.error('ok - skipping autonaming');
+            return clusterGeom()
+        }
 
         pool.connect((err, client, pg_done) => {
             if (err) return cb(err);


### PR DESCRIPTION
Rational: 
```
Network: Main St W
Address: Main St
```

`----------------|-------------------`

^ road with a small unnamed segmetn sticking out in the middle 

the autoname looks for addresses around it and names it `Main St` the linker then tries to link the OA points and is given a choice of `Main St W` or `Main St` it correctly picks Main St each time
which is that small tiny little autonamed segment in the middle since it will always = the address text perfectly


We'll always need autonaming for the AU but from the number of passrates that I'm seeing this affect I'm doubtful this is as useful in the US