### PR TITLE
correcting radius value for ST_Buffer

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -73,7 +73,7 @@ function match(min, max, cb) {
                     FROM
                         network_cluster n
                     WHERE
-                        ST_Intersects(ST_Buffer(MAX(a.geom), 0.02), n.geom)
+                        ST_Intersects(ST_Buffer(MAX(a.geom), 0.00018), n.geom)
                     ORDER BY dist
                 ) r
             ) AS nets


### PR DESCRIPTION
was debugging some memory heap issues, where the match step was exhausting the javascript heap allocation pretty immediately after starting.  here's an example of 700 network clusters matched to the one address. it's roughly a 2 km radius. is that what we intended? seems pretty wide an area.

![image](https://user-images.githubusercontent.com/1092694/34049081-16adc0ea-e184-11e7-8dcc-facb511f33f7.png)

I think we have the buffer set waaaaaay too big in `pt2itp/lib/match.js`.  From the postgis docs:

> ST_Buffer — (T) For geometry: Returns a geometry that represents all points whose distance from this Geometry is less than or equal to distance. **Calculations are in the Spatial Reference System of this Geometry.**

For geography types, the units are in km, but for geometries, they're in the units of the CRS, and for WGS 84, that means degrees.  At the equator, 1 degree = 111.31949 km.  If our intent is to have a buffer that's 0.02 km around each address point, we should be using `ST_Buffer(MAX(a.geom), 0.00018)`.