### PR TITLE
Diffname speed

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -117,6 +117,7 @@ function test(argv, cb) {
     }
 
     if (argv.limit) argv.limit = parseInt(argv.limit);
+    const limitClause = (argv.limit ? ' LIMIT ' + argv.limit : '');
 
     const pool = new pg.Pool({
         max: 10,
@@ -168,10 +169,10 @@ function test(argv, cb) {
                     return unmatched();
                 }
                 console.error('ok - beginning match');
-                client.query('SELECT count(*) FROM address WHERE netid IS NOT NULL', (err, res) => {
+                client.query(`SELECT count(*) FROM address WHERE netid IS NOT NULL ${limitClause}`, (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(a.geom) AS geom, a.number FROM address a WHERE netid IS NOT NULL' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
+                    const cursor = client.query(new Cursor(`SELECT a._text, ST_AsGeoJSON(a.geom) AS geom, a.number FROM address a WHERE netid IS NOT NULL ${limitClause} ;`));
 
                     const bar = new Prog('ok - Testing Network Matched Addresses [:bar] :percent :etas', {
                         complete: '=',
@@ -249,10 +250,10 @@ function test(argv, cb) {
                     return diffName();
                 }
                 console.error('ok - beginning unmatch');
-                client.query('SELECT count(*) FROM address_orphan_cluster a', (err, res) => {
+                client.query(`SELECT count(*) FROM address_orphan_cluster a ${limitClause}`, (err, res) => {
                     if (err) return cb(err);
 
-                    const cursor = client.query(new Cursor('SELECT a._text, ST_AsGeoJSON(ST_PointOnSurface(a.geom)) AS geom FROM address_orphan_cluster a' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
+                    const cursor = client.query(new Cursor(`SELECT a._text, ST_AsGeoJSON(ST_PointOnSurface(a.geom)) AS geom FROM address_orphan_cluster a ${limitClause} ;`));
 
                     const bar = new Prog('ok - Unmatched Addresses [:bar] :percent :etas', {
                         complete: '=',
@@ -298,26 +299,13 @@ function test(argv, cb) {
 
                 console.error('ok - beginning diff name');
                 client.query(`
-                    SELECT COUNT(*) FROM
-                        (SELECT * FROM address a WHERE netid IS NOT NULL) a
-                        WHERE a._text NOT IN
-                        (SELECT DISTINCT(UNNEST(REGEXP_SPLIT_TO_ARRAY(n._text, ','))) AS uniqtext FROM network_cluster n);
                     SELECT count(*) FROM address;
                 `, (err, res) => {
                     if (err) return cb(err);
 
-                    let totalDiffNames = res[0].rows[0].count;
-                    let totalAddresses = res[1].rows[0].count;
+                    let totalAddresses = res[0].rows[0].count;
 
                     const cursor = client.query(new Cursor('SELECT a._text AS atext, n._text AS ntext, ST_ASGeoJSON(ST_Centroid(a.geom)) AS center FROM address a LEFT JOIN network_cluster n ON a.netid = n.id WHERE a.netid IS NOT NULL AND a._text != any(regexp_split_to_array(n._text, \',\'))' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
-
-                    const bar = new Prog('ok - Name Mismatch [:bar] :percent :etas', {
-                        complete: '=',
-                        incomplete: ' ',
-                        width: 20,
-                        total: argv.limit || totalDiffNames++
-                    });
-                    bar.tick(1);
 
                     return iterate();
 
@@ -409,7 +397,6 @@ function test(argv, cb) {
                                 }
                             }
 
-                            bar.tick(cursor_it);
                             setImmediate(iterate);
                         });
                     }

--- a/lib/test.js
+++ b/lib/test.js
@@ -303,9 +303,23 @@ function test(argv, cb) {
                 `, (err, res) => {
                     if (err) return cb(err);
 
-                    let totalAddresses = res[0].rows[0].count;
+                    let totalAddresses = argv.limit || parseInt(res.rows[0].count);
 
-                    const cursor = client.query(new Cursor('SELECT a._text AS atext, n._text AS ntext, ST_ASGeoJSON(ST_Centroid(a.geom)) AS center FROM address a LEFT JOIN network_cluster n ON a.netid = n.id WHERE a.netid IS NOT NULL AND a._text != any(regexp_split_to_array(n._text, \',\'))' + (argv.limit ? ' LIMIT ' + argv.limit : '') + ';'));
+                    const cursor = client.query(new Cursor(`
+                        SELECT
+                            a._text AS atext,
+                            n._text AS ntext,
+                            ST_ASGeoJSON(ST_Centroid(a.geom)) AS center
+                        FROM
+                            address a
+                                LEFT JOIN
+                            network_cluster n ON a.netid = n.id
+                        WHERE
+                            a.netid IS NOT NULL
+                                AND
+                            a._text != any(regexp_split_to_array(n._text, \',\'))
+                        ${limitClause};`)
+                    );
 
                     return iterate();
 


### PR DESCRIPTION
It seems like https://github.com/ingalls/pt2itp/pull/272 has failed to speed things up sufficiently.  here's an example from the `br_sp` build, which has been running for almost 4 days:

```sql
EXPLAIN SELECT COUNT(*) FROM
  (SELECT * FROM address a WHERE netid IS NOT NULL) a
  WHERE a._text NOT IN
  (SELECT DISTINCT(UNNEST(REGEXP_SPLIT_TO_ARRAY(n._text, ','))) AS uniqtext FROM network_cluster n);
```
```
                                                QUERY PLAN
-----------------------------------------------------------------------------------------------------------
 Aggregate  (cost=1800887388976.58..1800887388976.59 rows=1 width=8)
   ->  Seq Scan on address a  (cost=45879.52..1800887375923.34 rows=5221295 width=0)
         Filter: ((netid IS NOT NULL) AND (NOT (SubPlan 1)))
         SubPlan 1
           ->  Materialize  (cost=45879.52..312425.84 rows=15802200 width=32)
                 ->  Unique  (cost=45879.52..125391.84 rows=15802200 width=32)
                       ->  Sort  (cost=45879.52..46525.24 rows=258287 width=32)
                             Sort Key: (unnest(regexp_split_to_array(n._text, ','::text)))
                             ->  Seq Scan on network_cluster n  (cost=0.00..16480.31 rows=258287 width=32)
(9 rows)
```

This PR removes the query for `totalDiffNames` altogether.  As it turns out, it was only used for the progress bar.  In the future, if we'd like to add the progress bar back, we can try to dream up a better query.