### PR TITLE
Update unit tests for map/strip-unit.js to accept street arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ and `number` containing the street address.
 | Property | Function |
 | :------: | -------- |
 | `number` | `String` The Housenumber for a given pt including any unit information. ie: `10a` |
-| `street` | `String` The name of the street - preferably non-abbreviated |
+| `street` | `String` or `Array` The name of the street - preferably non-abbreviated. If it's an array, it must contain an object for each street name synonym with the properties `display` for the street name and `priority` for the numeric ranking. |
 | `source` | `String` The source name of the data so a single input file can have a combination of multiple sources |
-| `output` | `Boolean` A boolean allowing pts to be used to calculate the ITP segement but not output in the final cluster |
+| `output` | `Boolean` A boolean allowing pts to be used to calculate the ITP segment but not output in the final cluster |
 
 ##### Example
 
 ```
 { "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": "Main Street", "number": 10 } }
-{ "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": "Main Street", "number": 11 } }
+{ "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": [ { "Main Street", "number": 11 } ] } }
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and `number` containing the street address.
 
 ```
 { "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": "Main Street", "number": 10 } }
-{ "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": [ { "Main Street", "number": 11 } ] } }
+{ "type": "Feature", "geometry": { "type": "Point", ... }, "properties": { "street": [ { display: "Main Street", priority: 0  } ], "number": 11 } }
 ...
 ```
 

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -10,22 +10,29 @@ function map(feat, context) {
     if (feat.geometry.type !== 'Point') return new Error('Feat must be a Point geom');
     if (!feat.properties) return new Error('Feat must have properties object');
     if (!feat.properties.number) return new Error('Feat must have number property');
-    if (!feat.properties.street) return new Error('Feat must have street property');
-    if (typeof feat.properties.street === 'string' && !feat.properties.street.trim().length) return new Error('Feat must have non-empty street property');
 
-    if (Array.isArray(feat.properties.street)) {
-        if (feat.properties.street.length <= 0) return new Error('Feat must have non-empty street property');
-        if (!feat.properties.street.some(syn => Object.keys(syn).includes('display')) || !feat.properties.street.some(syn => Object.keys(syn).includes('priority')) || !feat.properties.street.some(syn => Object.keys(syn).length === 2)) return new Error('Every synonym object in street array must contain only display and priority properties');
+    if (!feat.properties.street) return new Error('Feat must have street property');
+    if (typeof feat.properties.street === 'string') {
+        if (!feat.properties.street.trim().length) return new Error('Feat must have non-empty street property');
+
+        feat.properties.street = [{
+            display: feat.properties.street,
+            priority: 0
+        }];
+
+    } else if (Array.isArray(feat.properties.street)) {
+        if (!feat.properties.street.length) return new Error('Feat must have non-empty street property');
+        if (!feat.properties.street.some(syn => Object.keys(syn).includes('display')) || !feat.properties.street.some(syn => Object.keys(syn).includes('priority')) || !feat.properties.street.some(syn => Object.keys(syn).length === 2)) return new Error('Synonym objects in street array must contain only display and priority properties');
 
         for (let i = 0; i < feat.properties.street.length; i++) {
-            if (typeof feat.properties.street[i].display !== 'string' || isNaN(feat.properties.street[i].priority)) return new Error('Display property must be a string and priority property must be a number');
+            if (typeof feat.properties.street[i].display !== 'string' || isNaN(Number(feat.properties.street[i].priority))) return new Error('Display property must be a string and priority property must be a number');
         }
     }
 
     if (!feat.geometry.coordinates || !Array.isArray(feat.geometry.coordinates) || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
 
-    if (isNaN(feat.geometry.coordinates[0]) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
-    if (isNaN(feat.geometry.coordinates[1]) || feat.geometry.coordinates[1] < -85 || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');
+    if (isNaN(Number(feat.geometry.coordinates[0])) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
+    if (isNaN(Number(feat.geometry.coordinates[1])) || feat.geometry.coordinates[1] < -85 || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');
 
     if (typeof feat.properties.number !== 'string') feat.properties.number = String(feat.properties.number);
     feat.properties.number = feat.properties.number.toLowerCase();
@@ -44,14 +51,7 @@ function map(feat, context) {
 
     if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 
-    if (typeof feat.properties.street === 'string') {
-        feat.properties.street = [{
-            display: feat.properties.street,
-            priority: 0
-        }];
-    }
     return feat;
 }
-
 
 module.exports.map = map;

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -22,7 +22,7 @@ function map(feat, context) {
         }
     }
 
-    if (!feat.geometry.coordinates || !Array.isArray(feat.geometry.coordinates)  || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
+    if (!feat.geometry.coordinates || !Array.isArray(feat.geometry.coordinates) || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
 
     if (isNaN(feat.geometry.coordinates[0]) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
     if (isNaN(feat.geometry.coordinates[1]) || feat.geometry.coordinates[1] < -85 || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -11,9 +11,18 @@ function map(feat, context) {
     if (!feat.properties) return new Error('Feat must have properties object');
     if (!feat.properties.number) return new Error('Feat must have number property');
     if (!feat.properties.street) return new Error('Feat must have street property');
-    if (!feat.properties.street.trim().length) return new Error('Feat must have non-empty street property');
+    if (typeof feat.properties.street === 'string' && !feat.properties.street.trim().length) return new Error('Feat must have non-empty street property');
 
-    if (!feat.geometry.coordinates || !feat.geometry.coordinates instanceof Array || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
+    if (Array.isArray(feat.properties.street)) {
+        if (feat.properties.street.length <= 0) return new Error('Feat must have non-empty street property');
+        if (!feat.properties.street.some(syn => Object.keys(syn).includes('display')) || !feat.properties.street.some(syn => Object.keys(syn).includes('priority')) || !feat.properties.street.some(syn => Object.keys(syn).length === 2)) return new Error('Every synonym object in street array must contain only display and priority properties');
+
+        for (let i = 0; i < feat.properties.street.length; i++) {
+            if (typeof feat.properties.street[i].display !== 'string' || isNaN(feat.properties.street[i].priority)) return new Error('Display property must be a string and priority property must be a number');
+        }
+    }
+
+    if (!feat.geometry.coordinates || !Array.isArray(feat.geometry.coordinates)  || feat.geometry.coordinates.length !== 2) return new Error('Feat must have 2 element coordinates array');
 
     if (isNaN(feat.geometry.coordinates[0]) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
     if (isNaN(feat.geometry.coordinates[1]) || feat.geometry.coordinates[1] < -85 || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');
@@ -35,12 +44,14 @@ function map(feat, context) {
 
     if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 
-    feat.properties.street = [{
-        display: feat.properties.street,
-        priority: 0
-    }];
-
+    if (typeof feat.properties.street === 'string') {
+        feat.properties.street = [{
+            display: feat.properties.street,
+            priority: 0
+        }];
+    }
     return feat;
 }
+
 
 module.exports.map = map;

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -49,6 +49,48 @@ test('Strip-Unit', (t) => {
         type: 'Feature',
         properties: {
             number: 1,
+            street: []
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Feat must have non-empty street property', 'Feat must have non-empty street property');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: 1,
+            street: [{
+                name: 'Main St'
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Every synonym object in street array must contain only display and priority properties', 'Every synonym object in street array must contain only display and priority properties');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: 1,
+            street: [{
+                display: 'Main St',
+                priority: 'first'
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Display property must be a string and priority property must be a number', 'Display property must be a string and priority property must be a number');
+
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: 1,
             street: 'Main St'
         },
         geometry: {
@@ -64,7 +106,7 @@ test('Strip-Unit', (t) => {
         },
         geometry: {
             type: 'Point',
-            coordinates: [1000, 1000]
+            coordinates: [1000, 0]
         }
     }).toString(), 'Error: Feat exceeds +/-180deg coord bounds', 'Feat exceeds +/-180deg coord bounds');
 
@@ -95,7 +137,7 @@ test('Strip-Unit', (t) => {
     t.equals(map({
         type: 'Feature',
         properties: {
-            number: '423524268974602783406982734',
+            number: '42352426897',
             street: 'Main St'
         },
         geometry: {
@@ -203,8 +245,11 @@ test('Strip-Unit', (t) => {
     t.deepEquals(map({
         type: 'Feature',
         properties: {
-            number: '123 B',
-            street: 'Main St'
+            number: 1,
+            street: [{
+                display: 'Main St',
+                priority: 0
+            }]
         },
         geometry: {
             type: 'Point',
@@ -212,9 +257,32 @@ test('Strip-Unit', (t) => {
         }
     }), {
         geometry: { coordinates: [ 0, 0 ], type: 'Point' },
-        properties: { number: '123b', street: [{ display: 'Main St', priority: 0 }] },
+        properties: { number: '1', street: [{ display: 'Main St', priority: 0 }] },
         type: 'Feature'
-    }, 'Working 123 B => 123B Address');
+    }, 'Working street array address with one synonym');
+
+    t.deepEquals(map({
+        type: 'Feature',
+        properties: {
+            number: 1,
+            street: [{
+                display: 'Main St',
+                priority: 0
+            },
+            {
+                display: 'Hwy 101',
+                priority: 1
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }), {
+        geometry: { coordinates: [ 0, 0 ], type: 'Point' },
+        properties: { number: '1', street: [{ display: 'Main St', priority: 0 },{ display: 'Hwy 101', priority: 1 }] },
+        type: 'Feature'
+    }, 'Working street array address with two synonyms');
 
     t.end();
 });

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -69,7 +69,7 @@ test('Strip-Unit', (t) => {
             type: 'Point',
             coordinates: [0, 0]
         }
-    }).toString(), 'Error: Every synonym object in street array must contain only display and priority properties', 'Every synonym object in street array must contain only display and priority properties');
+    }).toString(), 'Error: Synonym objects in street array must contain only display and priority properties', 'Synonym objects in street array must contain only display and priority properties');
 
     t.equals(map({
         type: 'Feature',
@@ -106,7 +106,7 @@ test('Strip-Unit', (t) => {
         },
         geometry: {
             type: 'Point',
-            coordinates: [1000, 0]
+            coordinates: [1000, 1000]
         }
     }).toString(), 'Error: Feat exceeds +/-180deg coord bounds', 'Feat exceeds +/-180deg coord bounds');
 


### PR DESCRIPTION
As part of https://github.com/ingalls/pt2itp/pull/278, updates map/strip-unit.js and test/map.strip-unit.test.js to accept GeoJSON with a street property that can be either a string or a properly formatted array, e.g.:

```
properties: {
            number: 1,
            street: [{
                display: 'Main St',
                priority: 0
            }]
        }
```

## Next steps
- [x] Update README.md
- [ ] review by @ingalls 
- [ ] merge