### PR TITLE
US route

### DIFF
--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -64,12 +64,16 @@ function map(feat, context) {
     for (let i = 0; i < names.length; i++) {
         //United States Specific Name Formatting
         if (context.country === 'us') {
-            names[i].name = rename_us_hwy(names[i].name);
+            names[i].name = replace_octo(names[i].name);
+
+            let us_hwys = alts_us_route(names[i].name);
+            additional = additional.concat(us_hwys);
+            if (us_hwys.length) highway = true;
 
             if (context.region) {
-                let hwys = rename_state_hwy(context.region, names[i].name);
-                additional = additional.concat(hwys);
-                if (hwys.length > 0) highway = true;
+                let state_hwys = alts_state_hwy(context.region, names[i].name);
+                additional = additional.concat(state_hwys);
+                if (state_hwys.length) highway = true;
             }
         }
 
@@ -139,19 +143,62 @@ function map(feat, context) {
 }
 
 /**
+ * Replace names like "US 81 => US Route 81"
+ * @param {string} Name to edit
+ * @return {Array} of name alts
+ */
+function alts_us_route(name) {
+    if (!name) return;
+
+    let names = [];
+
+    let highway = false; //If truthy should be a string of the format 'US 81'
+    if (name.match(/^(U\.?S\.?|United States)(\s|-)(Rte |Route )?[0-9]+$/i)) {
+        highway = `US ${name.match(/[0-9]+/)[0]}`;
+    }
+
+    if (highway) {
+        let num = name.match(/[0-9]+/)[0];
+
+        //US 81
+        names.push({
+            name: highway,
+            priority: -1
+        });
+
+        //US Route 81 (Display Form)
+        names.push({
+            name: `US Route ${num}`,
+            priority: 1
+        });
+
+        //United States Route 81
+        names.push({
+            name: `United States Route ${num}`,
+            priority: -1
+        });
+    }
+
+    return names;
+
+
+}
+
+/**
  * Replace names like "NC 1 => North Carolina Highway 1"
  * Replace names like "State Highway 1 => NC 1, North Carolina Highway 1
  * @param {string} region Region of the US, usually a state
  * @param {string} name Name to edit
+ * @return {Array} of name alts
  */
-function rename_state_hwy(region, name) {
+function alts_state_hwy(region, name) {
     if (!name) return;
 
     let names = [];
 
     region = region.toUpperCase();
 
-    //The Goal is to get all input highways to CC #### and then format the matrix
+    //The Goal is to get all input highways to <STATE> #### and then format the matrix
     let highway = false;
     if (name.match(/^state (highway|hwy) /i)) {
         //State Highway 123
@@ -213,10 +260,10 @@ function rename_state_hwy(region, name) {
  * Removes the octothorpe from names like "HWY #35", to get "HWY 35"
  * @param {string} name Name to edit
  */
-function rename_us_hwy(name) {
+function replace_octo(name) {
     if (!name) return;
 
-    let octothorpePattern = new RegExp('^(HWY |HIGHWAY )(#)(\\d+)$');
+    let octothorpePattern = new RegExp('^(HWY |HIGHWAY |RTE |ROUTE |US )(#)(\\d+)$', 'i');
 
     let match = name.match(octothorpePattern);
     if (match) {

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -74,6 +74,7 @@ function map(feat, context) {
         }
 
         if (['au', 'ca', 'gb', 'nz', 'us'].indexOf(context.country) !== -1 && !highway) {
+            //Match 5 Avenue - no suffix
             let numericNameMatch = /^(\d+)(\s+\w.*)$/.exec(names[i].name);
 
             if (numericNameMatch) {

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -144,7 +144,7 @@ function map(feat, context) {
 
 /**
  * Replace names like "US 81 => US Route 81"
- * @param {string} Name to edit
+ * @param {string} name to edit
  * @return {Array} of name alts
  */
 function alts_us_route(name) {

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -64,10 +64,10 @@ function map(feat, context) {
     for (let i = 0; i < names.length; i++) {
         //United States Specific Name Formatting
         if (context.country === 'us') {
-            names[i].name = reformatUSHighway(names[i].name);
+            names[i].name = rename_us_hwy(names[i].name);
 
             if (context.region) {
-                let hwys = renameStateHwy(context.region, names[i].name);
+                let hwys = rename_state_hwy(context.region, names[i].name);
                 additional = additional.concat(hwys);
                 if (hwys.length > 0) highway = true;
             }
@@ -144,7 +144,7 @@ function map(feat, context) {
  * @param {string} region Region of the US, usually a state
  * @param {string} name Name to edit
  */
-function renameStateHwy(region, name) {
+function rename_state_hwy(region, name) {
     if (!name) return;
 
     let names = [];
@@ -213,7 +213,7 @@ function renameStateHwy(region, name) {
  * Removes the octothorpe from names like "HWY #35", to get "HWY 35"
  * @param {string} name Name to edit
  */
-function reformatUSHighway(name) {
+function rename_us_hwy(name) {
     if (!name) return;
 
     let octothorpePattern = new RegExp('^(HWY |HIGHWAY )(#)(\\d+)$');

--- a/lib/post/cardinality.js
+++ b/lib/post/cardinality.js
@@ -1,5 +1,7 @@
 /**
- * Exposes a post function to convert/filter ITP geometries as the last step before ouput
+ * Add cardinality Permutations to a given output
+ *
+ * W Main St => W Main St,Main St W,Main St
  *
  * @param {Object} feat     GeoJSON feature to convert/filter
  * @return {Object}         Output GeoJSON feature to write to output
@@ -7,42 +9,35 @@
 function post(feat) {
     if (!feat || !feat.properties || !feat.properties['carmen:text']) return feat;
 
-    let text = feat.properties['carmen:text'].split(',');
+    let texts = feat.properties['carmen:text'].split(',');
 
-    let prefixed = false;
-    let postfixed = false;
+    let postRegex = /\s(south|s|north|n|east|e|west|w)$/i;
+    let preRegex = /^(south|s|north|n|east|e|west|w)\s/i;
 
-    postRegex = /\s(south|s|north|n|east|e|west|w)$/i;
-    preRegex = /^(south|s|north|n|east|e|west|w)\s/i;
+    for (let t of texts) {
 
-    for (let t of text) {
-        if (!postfixed && t.match(postRegex)) {
-            postfixed = t;
+        //Main W => W Main,Main
+        if (t.match(postRegex)) {
+            let cardinal = t.match(postRegex);
+            let name = t.replace(postRegex, '');
+            let syn = `${cardinal[0]} ${name}`.trim();
+
+            if (texts.indexOf(syn) === -1) texts.push(syn);
+            if (texts.indexOf(name) === -1) texts.push(name);
         }
 
-        if (!prefixed && t.match(preRegex)) {
-            prefixed = t;
+        //W Main => Main W,Main
+        if (t.match(preRegex)) {
+            let cardinal = t.match(preRegex);
+            let name = t.replace(preRegex, '');
+            let syn = `${name} ${cardinal[0]}`.trim();
+
+            if (texts.indexOf(syn) === -1) texts.push(syn);
+            if (texts.indexOf(name) === -1) texts.push(name);
         }
-
-        if (prefixed && postfixed) return feat;
     }
 
-    if (prefixed) {
-        let cardinal = prefixed.match(preRegex);
-
-        let name = prefixed.replace(preRegex, '');
-
-        text.push(`${name} ${cardinal[0]}`.trim());
-    }
-
-    if (postfixed) {
-        let cardinal = postfixed.match(postRegex);
-        let name = postfixed.replace(postRegex, '');
-
-        text.push(`${cardinal[0]} ${name}`.trim());
-    }
-
-    feat.properties['carmen:text'] = text.join(',');
+    feat.properties['carmen:text'] = texts.join(',');
 
     return feat;
 }

--- a/test/map.osmium.test.js
+++ b/test/map.osmium.test.js
@@ -250,7 +250,35 @@ test('Osmium', (t) => {
             { type: 'Feature', properties: { id: 3, street: { display: 'Pennsylvania Highway 123', priority: 1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } },
             { type: 'Feature', properties: { id: 3, street: { display: 'Highway 123', priority: -1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } },
             { type: 'Feature', properties: { id: 3, street: { display: 'State Highway 123', priority: -1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } }
-        ], name);
+        ], `STATE HIGHWAY: ${name}`);
+    }
+
+    for (let name of [
+        'us-81',
+        'US 81',
+        'U.S. Route 81',
+        'US Route 81',
+        'US Rte 81',
+        'United States 81',
+        'United States Route 81',
+    ]) {
+        t.deepEquals(map({
+            type: 'Feature',
+            properties: {
+                highway: 'motorway',
+                "@id": 3,
+                name: name
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,0],[1,1]]
+            }
+        }, { country: "us", region: "pa"}), [
+             { type: 'Feature', properties: { id: 3, street: { display: name, priority: 0 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } },
+             { type: 'Feature', properties: { id: 3, street: { display: 'US 81', priority: -1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } },
+             { type: 'Feature', properties: { id: 3, street: { display: 'US Route 81', priority: 1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } },
+             { type: 'Feature', properties: { id: 3, street: { display: 'United States Route 81', priority: -1 } }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } }
+        ], `US ROUTE: ${name}`);
     }
 
     t.end();

--- a/test/post.cardinality.test.js
+++ b/test/post.cardinality.test.js
@@ -12,25 +12,24 @@ test('Post: Cardinality', (t) => {
 
     t.equals(f('Test'), 'Test');
     t.equals(f('Main St'), 'Main St');
-    t.equals(f('S Main St'), 'S Main St,Main St S');
-    t.equals(f('South Main St'), 'South Main St,Main St South');
-    t.equals(f('Main St South'), 'Main St South,South Main St');
-        //
-    //At the moment we don't try to see if the synonyms are the same just that if there is a prefix/postfix existing already to skip
-    t.equals(f('South Main St,Fake St South'), 'South Main St,Fake St South');
+    t.equals(f('S Main St'), 'S Main St,Main St S,Main St');
+    t.equals(f('South Main St'), 'South Main St,Main St South,Main St');
+    t.equals(f('Main St South'), 'Main St South,South Main St,Main St');
+
+    t.equals(f('South Main St,Fake St South'), 'South Main St,Fake St South,Main St South,Main St,South Fake St,Fake St');
 
     //Random Sample From SG File
     t.equals(f('TUAS SOUTH BOULEVARD'), 'TUAS SOUTH BOULEVARD'); //We don't handle this format atm
     t.equals(f('JURONG WEST AVENUE'), 'JURONG WEST AVENUE');
 
-    t.equals(f('ADMIRALTY ROAD EAST'), 'ADMIRALTY ROAD EAST,EAST ADMIRALTY ROAD');
-    t.equals(f('ADMIRALTY ROAD WEST'), 'ADMIRALTY ROAD WEST,WEST ADMIRALTY ROAD');
-    t.equals(f('EAST COAST PARKWAY'), 'EAST COAST PARKWAY,COAST PARKWAY EAST');
-    t.equals(f('CORONATION ROAD WEST'), 'CORONATION ROAD WEST,WEST CORONATION ROAD');
-    t.equals(f('BEDOK INDUSTRIAL PARK E'), 'BEDOK INDUSTRIAL PARK E,E BEDOK INDUSTRIAL PARK');
-    t.equals(f('WEST COAST WALK'), 'WEST COAST WALK,COAST WALK WEST');
-    t.equals(f('TANJONG KATONG ROAD SOUTH'), 'TANJONG KATONG ROAD SOUTH,SOUTH TANJONG KATONG ROAD');
-    t.equals(f('WEST COAST VIEW'), 'WEST COAST VIEW,COAST VIEW WEST');
+    t.equals(f('ADMIRALTY ROAD EAST'), 'ADMIRALTY ROAD EAST,EAST ADMIRALTY ROAD,ADMIRALTY ROAD');
+    t.equals(f('ADMIRALTY ROAD WEST'), 'ADMIRALTY ROAD WEST,WEST ADMIRALTY ROAD,ADMIRALTY ROAD');
+    t.equals(f('EAST COAST PARKWAY'), 'EAST COAST PARKWAY,COAST PARKWAY EAST,COAST PARKWAY');
+    t.equals(f('CORONATION ROAD WEST'), 'CORONATION ROAD WEST,WEST CORONATION ROAD,CORONATION ROAD');
+    t.equals(f('BEDOK INDUSTRIAL PARK E'), 'BEDOK INDUSTRIAL PARK E,E BEDOK INDUSTRIAL PARK,BEDOK INDUSTRIAL PARK');
+    t.equals(f('WEST COAST WALK'), 'WEST COAST WALK,COAST WALK WEST,COAST WALK');
+    t.equals(f('TANJONG KATONG ROAD SOUTH'), 'TANJONG KATONG ROAD SOUTH,SOUTH TANJONG KATONG ROAD,TANJONG KATONG ROAD');
+    t.equals(f('WEST COAST VIEW'), 'WEST COAST VIEW,COAST VIEW WEST,COAST VIEW');
 
     t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,8 +46,8 @@
     xregexp "3.1.1"
 
 "@mapbox/geocoder-abbreviations@^2.1.2":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-2.1.3.tgz#013b97f8023fb19975ded073271b6c6a94b6749d"
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-2.1.4.tgz#2f76bbfdb66611b4fced4b8e48ba8ed680f8c314"
   dependencies:
     tape "^4.6.3"
 
@@ -2209,8 +2209,8 @@ browser-resolve@^1.7.0:
     resolve "1.1.7"
 
 browserslist@^2.1.2:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.1.tgz#f9dc692b79004a78ec9ba0d012c54de44cc6d7e4"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.0.tgz#50350d6873a82ebe0f3ae5483658c571ae5f9d7d"
   dependencies:
     caniuse-lite "^1.0.30000784"
     electron-to-chromium "^1.3.30"
@@ -2280,8 +2280,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000784:
-  version "1.0.30000784"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz#129ced74e9a1280a441880b6cd2bce30ef59e6c0"
+  version "1.0.30000789"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz#2e3d937b267133f63635ef7f441fac66360fc889"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2814,8 +2814,8 @@ doctrine-temporary-fork@2.0.0-alpha-allowarrayindex:
     isarray "^1.0.0"
 
 doctrine@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
 
@@ -2888,8 +2888,8 @@ duplexify@^3.1.2:
     stream-shift "^1.0.0"
 
 earcut@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.2.tgz#542add0ca3a7b713452720e1d053937d3daf3784"
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.3.tgz#ca579545f351941af7c3d0df49c9f7d34af99b0c"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -3039,8 +3039,8 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^4.6.1:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.14.0.tgz#96609768d1dd23304faba2d94b7fefe5a5447a82"
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.15.0.tgz#89ab38c12713eec3d13afac14e4a89e75ef08145"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -4691,8 +4691,8 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     regex-cache "^0.4.2"
 
 micromatch@^3.0.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.4.tgz#bb812e741a41f982c854e42b421a7eac458796f4"
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -4832,8 +4832,8 @@ nan@~2.7.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 nanomatch@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.6.tgz#f27233e97c34a8706b7e781a4bc611c957a81625"
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -5142,14 +5142,20 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
 packet-reader@0.3.1:
   version "0.3.1"
@@ -5329,8 +5335,8 @@ pg-types@~1.12.1:
     postgres-interval "^1.1.0"
 
 pg@^7.3.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-7.4.0.tgz#e256061d2c52723c3c858defb97f1159ca660f83"
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.4.1.tgz#f3411c8ddf9f692322fe05e7017a1888e47f78f1"
   dependencies:
     buffer-writer "1.0.1"
     js-string-escape "1.0.1"


### PR DESCRIPTION
- Update deps to the latest and greatest
- Add support for a wide range of US Route synonyms
- Add support for `five => 5` matches in network names
- Refactor `post/cardinality` to support `FreeRadicals` text changes
- Add cardinality stripping to `post/cardinality`
  
  