### PR TITLE
Handle empty string and non-string or num address numbers

### DIFF
--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -16,7 +16,7 @@ function map(feat, context) {
     } else if (typeof feat.properties.number === 'number') {
         feat.properties.number = String(feat.properties.number);
     } else {
-        return new Error('Feat must have a string or number number property');
+        return new Error('Feat must have a string or numeric number property');
     }
 
     feat.properties.number = feat.properties.number.toLowerCase();

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -9,7 +9,28 @@ function map(feat, context) {
     //Skip points & Polygons
     if (feat.geometry.type !== 'Point') return new Error('Feat must be a Point geom');
     if (!feat.properties) return new Error('Feat must have properties object');
+
     if (!feat.properties.number) return new Error('Feat must have number property');
+    if (typeof feat.properties.number === 'string') {
+        if (!feat.properties.number.trim().length) return new Error('Feat must have non-empty number property');
+    } else if (typeof feat.properties.number === 'number') {
+        feat.properties.number = String(feat.properties.number);
+    } else {
+        return new Error('Feat must have a string or number number property');
+    }
+
+    feat.properties.number = feat.properties.number.toLowerCase();
+
+    //Transform addresses that are almost supported to a supported type
+    feat.properties.number = feat.properties.number.replace(/\s1\/2$/, '');
+
+    //123 B => 123B
+    if (/^\d+\s[a-z]$/.test(feat.properties.number)) feat.properties.number = feat.properties.number.replace(/\s/g, '');
+
+    //Don't add new address formats here without adding them to carmen first. Addresses need to be converted to one of these formats or dropped
+    if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat is not a supported address/unit type');
+
+    if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 
     if (!feat.properties.street) return new Error('Feat must have street property');
     if (typeof feat.properties.street === 'string') {
@@ -33,23 +54,6 @@ function map(feat, context) {
 
     if (isNaN(Number(feat.geometry.coordinates[0])) || feat.geometry.coordinates[0] < -180 || feat.geometry.coordinates[0] > 180) return new Error('Feat exceeds +/-180deg coord bounds');
     if (isNaN(Number(feat.geometry.coordinates[1])) || feat.geometry.coordinates[1] < -85 || feat.geometry.coordinates[1] > 85) return new Error('Feat exceeds +/-85deg coord bounds');
-
-    if (typeof feat.properties.number !== 'string') feat.properties.number = String(feat.properties.number);
-    feat.properties.number = feat.properties.number.toLowerCase();
-
-    //Transform addresses that are almost supported to a supported type
-
-    feat.properties.number = feat.properties.number.replace(/\s1\/2$/, '');
-
-    //123 B => 123B
-    if (/^\d+\s[a-z]$/.test(feat.properties.number)) {
-        feat.properties.number = feat.properties.number.replace(/\s/g, '');
-    }
-
-    //Don't add new address formats here without adding them to carmen first. Addresses need to be converted to one of these formats or dropped
-    if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat is not a supported address/unit type');
-
-    if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 
     return feat;
 }

--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -28,7 +28,7 @@ function map(feat, context) {
     if (/^\d+\s[a-z]$/.test(feat.properties.number)) feat.properties.number = feat.properties.number.replace(/\s/g, '');
 
     //Don't add new address formats here without adding them to carmen first. Addresses need to be converted to one of these formats or dropped
-    if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat is not a supported address/unit type');
+    if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat number is not a supported address/unit type');
 
     if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -27,6 +27,52 @@ test('Strip-Unit', (t) => {
     t.equals(map({
         type: 'Feature',
         properties: {
+            number: ' \t '
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Feat must have non-empty number property', 'Feat must have non-empty number property');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: []
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Feat must have a string or number number property', 'Feat must have a string or number number property');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: 'xyz',
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Feat number is not a supported address/unit type', 'Feat is not a supported address/unit type');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
+            number: '42352426897',
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }).toString(), 'Error: Number should not exceed 10 chars', 'Number should not exceed 10 chars');
+
+    t.equals(map({
+        type: 'Feature',
+        properties: {
             number: 1
         },
         geometry: {
@@ -133,30 +179,6 @@ test('Strip-Unit', (t) => {
             coordinates: [0, 1000]
         }
     }).toString(), 'Error: Feat exceeds +/-85deg coord bounds', 'Feat exceeds +/-85deg coord bounds');
-
-    t.equals(map({
-        type: 'Feature',
-        properties: {
-            number: 'xyz',
-            street: 'Main St'
-        },
-        geometry: {
-            type: 'Point',
-            coordinates: [0, 0]
-        }
-    }).toString(), 'Error: Feat is not a supported address/unit type', 'Feat is not a supported address/unit type');
-
-    t.equals(map({
-        type: 'Feature',
-        properties: {
-            number: '42352426897',
-            street: 'Main St'
-        },
-        geometry: {
-            type: 'Point',
-            coordinates: [0, 0]
-        }
-    }).toString(), 'Error: Number should not exceed 10 chars', 'Number should not exceed 10 chars');
 
     t.deepEquals(map({
         type: 'Feature',
@@ -298,4 +320,3 @@ test('Strip-Unit', (t) => {
 
     t.end();
 });
-

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -44,7 +44,7 @@ test('Strip-Unit', (t) => {
             type: 'Point',
             coordinates: [0, 0]
         }
-    }).toString(), 'Error: Feat must have a string or numeric number property', 'Feat must have a string or number number property');
+    }).toString(), 'Error: Feat must have a string or numeric number property', 'Feat must have a string or numeric number property');
 
     t.equals(map({
         type: 'Feature',

--- a/test/map.strip-unit.test.js
+++ b/test/map.strip-unit.test.js
@@ -44,7 +44,7 @@ test('Strip-Unit', (t) => {
             type: 'Point',
             coordinates: [0, 0]
         }
-    }).toString(), 'Error: Feat must have a string or number number property', 'Feat must have a string or number number property');
+    }).toString(), 'Error: Feat must have a string or numeric number property', 'Feat must have a string or number number property');
 
     t.equals(map({
         type: 'Feature',
@@ -56,7 +56,7 @@ test('Strip-Unit', (t) => {
             type: 'Point',
             coordinates: [0, 0]
         }
-    }).toString(), 'Error: Feat number is not a supported address/unit type', 'Feat is not a supported address/unit type');
+    }).toString(), 'Error: Feat number is not a supported address/unit type', 'Feat number is not a supported address/unit type');
 
     t.equals(map({
         type: 'Feature',


### PR DESCRIPTION
## Context

Addresses https://github.com/ingalls/pt2itp/issues/291 where given a GeoJSON feature with a non-empty whitespace `number` property, we returned `Error: Feat is not a supported address/unit type` rather than a `number` property error.

While I was looking into this, I added error handling for non string or number `number` properties and moved all address number parsing code together so if follows a similar format to how we're parsing the `street` property.

## Summary of changes
- [x] added a check for whitespace `number` property values and a unit test
- [x] added a check for non string or number `number` property values and a unit test
- [x] moved all code that handles the `number` property together

## Next steps 
- [ ] review by @trescube and @ingalls 
- [ ] merge & release