### PR TITLE
Use max JS integer size when setting ID

### DIFF
--- a/lib/post/id.js
+++ b/lib/post/id.js
@@ -6,6 +6,8 @@
 function post(feat) {
     if (!feat) return feat;
 
+    // Use all 53 bits we have available when setting ID
+    // This lowers, but does not remove, the chance of a collision
     feat.id = Math.floor((Math.random() * Number.MAX_SAFE_INTEGER) + 1);
 
     return feat;

--- a/lib/post/id.js
+++ b/lib/post/id.js
@@ -6,7 +6,7 @@
 function post(feat) {
     if (!feat) return feat;
 
-    feat.id = Math.floor((Math.random() * 2147483647) + 1);
+    feat.id = Math.floor((Math.random() * Number.MAX_SAFE_INTEGER) + 1);
 
     return feat;
 }


### PR DESCRIPTION
PT2ITP currently only uses 31 bits for IDs, which leads to ID collisions with some degree of frequency. This updates the ID script to use [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), an alias for 2^53 - 1 that's a little easier for humans to understand and read.