### PR TITLE
analyze.js tweaks: use tokenized field

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -441,7 +441,7 @@ function compareAddressAndNetwork(argv, pool, callback) {
                 FROM
                     bigram_comparison
                 WHERE
-                    zscore > 1
+                    zscore > 0.1
                 ORDER BY
                     zscore DESC, w1, w2;
 
@@ -456,7 +456,7 @@ function compareAddressAndNetwork(argv, pool, callback) {
                 FROM
                     bigram_comparison
                 WHERE
-                    zscore < -1
+                    zscore < -0.1
                 ORDER BY
                     zscore, w1, w2;
             COMMIT;`,
@@ -549,7 +549,7 @@ function compareAddressAndNetwork(argv, pool, callback) {
                 FROM
                     unigram_comparison
                 WHERE
-                    zscore > 1
+                    zscore > 0.1
                 ORDER BY
                     zscore DESC, word;
 
@@ -563,7 +563,7 @@ function compareAddressAndNetwork(argv, pool, callback) {
                 FROM
                     unigram_comparison
                 WHERE
-                    zscore < -1
+                    zscore < -0.1
                 ORDER BY
                     zscore,word;
             COMMIT;`,

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -318,7 +318,7 @@ function formatData(data) {
     data.forEach(d => {
         if (!d.name || !d.name.length) return;
         d.name.forEach(name => {
-            return results.push(name.display);
+            return results.push(name.tokenized);
         });
     });
 


### PR DESCRIPTION
The results of the `analyze` command are meant to be useful for identifying tokens that might prevent matches between addresses and networks.  Currently, though, it is doing a statistical analysis of the `display` properties in `address.name` and `network.name`. It ends up, however, reporting a lot of tokens that are already handled by our tokenization process, which collapses variants of things like address suffixes (eg "Road" vs "Rd").

A more informative analysis would describe the `tokenized` property of these name fields, which benefits from token normalization and is the field actually used when matching address and network records.