### PR TITLE
Cluster networks on full JSON field

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -247,9 +247,7 @@ class Cluster {
                             json_array_elements(json_array_elements(JSON_AGG(name)))::JSONB AS name,
                             unnest(ST_ClusterWithin(geom, 0.005)) AS geom
                         FROM network
-                        WHERE
-                            name->0->>'tokenized' != ''
-                            AND id = ANY(ARRAY[8643835,8647571,8650742,8650830,8651763,27804024,41743612,42824879,48920382,86485220,86485221,86485222,91996461,93120170,93120183,102720543,479772])
+                        WHERE name->0->>'tokenized' != ''
                         GROUP BY name->0
                     ) netw
                     GROUP BY

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -236,16 +236,28 @@ class Cluster {
 
             INSERT INTO network_cluster(name, geom)
                 SELECT
-                    name::JSONB AS name,
-                    ST_Multi(ST_CollectionExtract(netw.geom, 2)) AS geom
+                    JSON_AGG(name),
+                    geom
                 FROM (
                     SELECT
-                        MAX(name::TEXT) AS name,
-                        unnest(ST_ClusterWithin(geom, 0.005)) AS geom
-                    FROM network
-                    WHERE name->0->>'tokenized' != ''
-                    GROUP BY name->0->>'tokenized'
-                ) netw;
+                        name,
+                        ST_Multi(ST_CollectionExtract(netw.geom, 2)) AS geom
+                    FROM (
+                        SELECT
+                            json_array_elements(json_array_elements(JSON_AGG(name)))::JSONB AS name,
+                            unnest(ST_ClusterWithin(geom, 0.005)) AS geom
+                        FROM network
+                        WHERE
+                            name->0->>'tokenized' != ''
+                            AND id = ANY(ARRAY[8643835,8647571,8650742,8650830,8651763,27804024,41743612,42824879,48920382,86485220,86485221,86485222,91996461,93120170,93120183,102720543,479772])
+                        GROUP BY name->0
+                    ) netw
+                    GROUP BY
+                        geom,
+                        name
+                    ORDER BY name->>'priority'
+                ) final
+                GROUP BY geom;
 
             -- extracts distinct Z coordinates from a multilinestring
             CREATE OR REPLACE FUNCTION get_source_ids(geometry(MultiLineStringZ))


### PR DESCRIPTION
A customer reported an incorrect street name for `Pike Drive` that should have been `Park Drive`

None of the component streets were names `Pike Drive`

```
Networks:
-------------  ------------ -------------
Park Drive  Park Drive     Park Drive

Cluster:
------------------------------------
Pike Drive
```

But yet the cluster was being named `Pike Drive`

I noticed that `Pike` and `Park` both abbreviate to `Pk` in our geocoder-abbreviations: https://github.com/mapbox/geocoder-abbreviations/commit/ffd994172bb315710b570f308590075b628e367b#diff-b87dd7367114931bd30f6f7c93a03a99R929

At first I thought that the display field was being improperly modified (The only operation that should be performed on it is the TitleCase operation at the very end) which would not result in the database being updated.

This lead me to review the cluster code where I discovered that the networks were first grouped on the `tokenized` field before being clustered.

Since `Park Drive` and `Pike Drive` both have a tokenized value of `pk dr`, they were grouped together and then the MAX of the `name` field was taken. At this point it was a crapshoot as to whether `Park Drive` or `Pike Drive` would happen to win.

---

This PR groups on the first element of the name array - the `Primary` name per the docs, exploding the primary and seconds names, then deduping based on clustered geometry before reassembling into the name array