### PR TITLE
You wouldn't believe this address format!

### DIFF
--- a/lib/map/strip-unit.js
+++ b/lib/map/strip-unit.js
@@ -29,7 +29,12 @@ function map(feat, context) {
     if (/^\d+\s[a-z]$/.test(feat.properties.number)) feat.properties.number = feat.properties.number.replace(/\s/g, '');
 
     //Don't add new address formats here without adding them to carmen first. Addresses need to be converted to one of these formats or dropped
-    if (!/^\d+[a-z]?$/.test(feat.properties.number) && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number)) return new Error('Feat number is not a supported address/unit type');
+    if (
+        !/^\d+[a-z]?$/.test(feat.properties.number) ////10 or 10a Style
+        && !/^(\d+)-(\d+)[a-z]?$/.test(feat.properties.number) // 10-19 or 10-19a Style
+        && !/^(\d+)([nsew])(\d+)[a-z]?$/.test(feat.properties.number) // 6N23 Style (ie Kane County, IL)
+        && !/^([nesw])(\d+)([nesw]\d+)?$/.test(feat.properties.number) //W350N5337 or N453 Style (ie Waukesha County, WI)
+    ) return new Error('Feat number is not a supported address/unit type');
 
     if (feat.properties.number.length > 10) return new Error('Number should not exceed 10 chars');
 


### PR DESCRIPTION
### Context

A customer has reported that addresses for the Town of Oconomowoc, WI fail to geocode.

Per the town code: https://ecode360.com/15607678

```
§ 85-5 Numbering system.
A. One hundred numbers shall be assigned to each invisible block, regardless of discrepancies in block sizes. Properties on the north and east sides of streets shall bear even numbers, and properties on the south and west sides of streets shall bear odd numbers.
B. The number assigned to each property shall be composed of two parts. The first part, or street designation, shall be composed of a directional letter, "N," "S," "W," followed by the number of the appropriate block line.
C. The second part of the property number, the block and house designation, shall be composed of a directional letter followed by the number of the appropriate block line plus two additional digits indicating the relative position of the property in the block.
D. For a block which lies south of the east-west baseline, the designation of the block shall be by the block line numbers of its north and its east boundaries. For a block which lies north of the east-west baseline, the designation of the block shall be by the block line numbers of its south and its east boundaries.
E. Properties and street intersections contained within any block shall bear numbers and directional letters related to the point of intersection of the block boundary lines stipulated in the subsection next above.
```

This PR introduces support for this address type.

Ref: https://github.com/mapbox/carmen/pull/700 