### PR TITLE
handle non-string values in geocoder_tokens

### DIFF
--- a/lib/testcsv.js
+++ b/lib/testcsv.js
@@ -82,7 +82,17 @@ function test(argv, cb) {
     const tokens = {};
 
     for (let token in tokens_raw) {
-        tokens[diacritics(token.toLowerCase())] = diacritics(tokens_raw[token].toLowerCase());
+        const value = tokens_raw[token];
+        let value_string;
+        if (typeof value == 'object') {
+            value_string = value['text'];
+        }
+        else if (typeof value == 'string') {
+            value_string = value;
+        } else {
+            throw new Error(`not ok - testcsv doesn't know how to handle geocoder_tokens mapping: { "${token}": ${JSON.stringify(value)} }`);
+        }
+        tokens[diacritics(token.toLowerCase())] = diacritics(value_string.toLowerCase());
     }
 
     const c = geocode(carmencnf);


### PR DESCRIPTION
`testcsv` fails when the config's `geocoder_tokens` contains values that are not strings, such as:

```
"ä": {
    "skipBoundaries": true,
    "skipDiacriticStripping": true,
    "text": "ae"
},
```

This handles those cases by using the `"text"` value.

NOTE: this solution punts on the idea of doing the same thing carmen does with these entries.  the result may be some specious `TEXT` errors, eg:

| resultType | query | queryPoint | addressText | returnedPoint | 
| ---- | ----------------------------------- | ------------------------------------ | ---------------------- | ------------------ |
| TEXT | toessfeld str 30                    | 8.713705000000001,47.491768          | 30 tossfeld str        | 8.713744,47.491747 |
| TEXT | hoeheweg 94                         | 7.865952,46.689602                   | 94 hoheweg             | 7.866003,46.689651 |
| TEXT | schoenau str 10                     | 7.599278,47.5676                     | 10 schonau str         | 7.599289,47.567588 |
| TEXT | doeltschihalde 49                   | 8.49702,47.364232                    | 49 doltschihalde       | 8.496849,47.364247 |