### PR TITLE
Redirect error to file

### DIFF
--- a/lib/conflate.js
+++ b/lib/conflate.js
@@ -125,7 +125,7 @@ function main(argv, cb) {
             child.stdout.on('error', epipe);
             child.stderr.on('error', epipe);
 
-            if (opts.error) child.stderr.pipe(argv['error-conflate']);
+            if (argv['error-conflate']) child.stderr.pipe(argv['error-conflate']);
             else child.stderr.pipe(process.stderr);
 
             child.send({

--- a/test/conflate.compare.test.js
+++ b/test/conflate.compare.test.js
@@ -35,6 +35,7 @@ test('conflate/compare - compare', (t) => {
 
         q.deepEquals(res, {
             action: 'create',
+            type: 'Feature',
             properties: {
                 number: 1,
                 source: 'test',
@@ -92,6 +93,7 @@ test('conflate/compare - compare', (t) => {
 
         q.deepEquals(res, {
             action: 'create',
+            type: 'Feature',
             properties: {
                 number: 1,
                 source: 'test',
@@ -195,6 +197,7 @@ test('conflate/compare - compare', (t) => {
 
         q.deepEquals(res, {
             action: 'create',
+            type: 'Feature',
             properties: {
                 number: 1,
                 source: 'test',
@@ -257,6 +260,7 @@ test('conflate/compare - compare', (t) => {
 
         q.deepEquals(res, {
             action: 'create',
+            type: 'Feature',
             properties: {
                 number: 1,
                 source: 'test',


### PR DESCRIPTION
Fix bug where error output would go to `stderr` instead of the file specified.