### PR TITLE
Drop Drive In Roads

### DIFF
--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -91,7 +91,7 @@ function map(feat, context) {
 
         //United States Specific Name Formatting
         if (context.country === 'us') {
-            if (names[i].display.match(/drive.?in$/i)) return false;
+            if (names[i].display.match(/drive.?(in|through)$/i)) return false;
 
             // Name Synonyms
             names[i].display = replace_octo(names[i].display);

--- a/lib/map/osmium.js
+++ b/lib/map/osmium.js
@@ -91,6 +91,9 @@ function map(feat, context) {
 
         //United States Specific Name Formatting
         if (context.country === 'us') {
+            if (names[i].display.match(/drive.?in$/i)) return false;
+
+            // Name Synonyms
             names[i].display = replace_octo(names[i].display);
 
             let us_hwys = alts_us_route(names[i].display, i === 0 ? true : false);

--- a/test/map.osmium.test.js
+++ b/test/map.osmium.test.js
@@ -148,6 +148,26 @@ test('Osmium', (t) => {
         }
     },{country: "us"}), { type: 'Feature', properties: { id: 3, street: [ { display: 'name', priority: 0 }, { display: 'HWY 35', priority: -1 } ] }, geometry: { type: 'LineString', coordinates: [ [ 0, 0 ], [ 1, 1 ] ] } }, 'HWY # replaced');
 
+    // Ensure drop overrides are dropped
+    for (let name of [
+        'Burger King Drive-in',
+        'Burger King Drivein',
+        'Burger King Drive in'
+    ]) {
+        t.deepEquals(map({
+            type: 'Feature',
+            properties: {
+                highway: 'motorway',
+                "@id": 3,
+                name: name
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,0],[1,1]]
+            }
+        }, { country: "us", region: "pa"}), false, `${name} was dropped`);
+    }
+    
     // handle suffixless numeric streets
     let streets = [
         ['1 Ave', 'st'],

--- a/test/map.osmium.test.js
+++ b/test/map.osmium.test.js
@@ -152,7 +152,10 @@ test('Osmium', (t) => {
     for (let name of [
         'Burger King Drive-in',
         'Burger King Drivein',
-        'Burger King Drive in'
+        'Burger King Drive in',
+        'Burger King Drive-through',
+        'Burger King Drivethrough',
+        'Burger King Drive through'
     ]) {
         t.deepEquals(map({
             type: 'Feature',

--- a/test/map.osmium.test.js
+++ b/test/map.osmium.test.js
@@ -170,7 +170,7 @@ test('Osmium', (t) => {
             }
         }, { country: "us", region: "pa"}), false, `${name} was dropped`);
     }
-    
+
     // handle suffixless numeric streets
     let streets = [
         ['1 Ave', 'st'],


### PR DESCRIPTION
Drive in roads are often mapped in OpenStreetMap with the type

```
Wendy's Drive in
Burger King Drive in
...
```

This PR adds a drop function to remove these before address matching