### PR TITLE
Backfill cluster names instead of carrying them through

### DIFF
--- a/lib/util/cluster.js
+++ b/lib/util/cluster.js
@@ -344,10 +344,8 @@ class Cluster {
         this.pool.query(`
             BEGIN TRANSACTION;
 
-            INSERT INTO network_cluster(name, geom)
-                SELECT
-                    JSON_AGG(name),
-                    geom
+            INSERT INTO network_cluster(geom)
+                SELECT geom
                 FROM (
                     SELECT
                         name,
@@ -395,6 +393,29 @@ class Cluster {
 
             UPDATE network_cluster
                 SET source_ids = get_source_ids(geom);
+
+            UPDATE network_cluster
+                SET name = final.name
+                FROM (
+                    SELECT
+                        joined.id,
+                        json_agg(joined.name) AS name
+                    FROM (
+                        SELECT DISTINCT
+                            nc.id,
+                            jsonb_array_elements(n.name) AS name
+                        FROM (
+                            SELECT
+                                id,
+                                unnest(source_ids) AS sources
+                                FROM network_cluster
+                            ) nc,
+                            network n
+                        WHERE n.id = sources
+                    ) joined
+                    GROUP BY joined.id
+                ) final
+                WHERE final.id = network_cluster.id
 
             ALTER TABLE network_cluster
                 ADD COLUMN geom_flat geometry(geometry, 4326);


### PR DESCRIPTION
The current approach to network clustering had an unanticipated side affect of pooling synonyms together before they were split.

IE:

Input Features
```
The Drive
The Drive, Park Lane
The Drive,Route 85,State Rd 103
```

The features were then clustered on their primary id and split based on the clustered value.
However synonyms were shared accross the cluster pool, resulting in each final feature having the text

```
The Drive,Park Lane,Route 85,State Rd 103
```

This removes carrying the name through clustering and instead taking the approach of back-filling it from the final `source_ids` column.