### PR TITLE
Add accuracy intersection tag

### DIFF
--- a/lib/map/intersections.js
+++ b/lib/map/intersections.js
@@ -98,7 +98,8 @@ class Intersections {
                         type: 'Feature',
                         properties: {
                             'carmen:text': names.join(','),
-                            'carmen:geocoder_stack': opts.country ? opts.country : undefined
+                            'carmen:geocoder_stack': opts.country ? opts.country : undefined,
+                            accuracy: 'intersection'
                         },
                         geometry: JSON.parse(intsec.geom)
                     }));

--- a/test/intersections.test.js
+++ b/test/intersections.test.js
@@ -30,7 +30,8 @@ test('Intersections', async(t) => {
             properties: {
                 'carmen:text': 'Main Street and 1st Avenue,1st Avenue and Main Street',
                 'carmen:geocoder_stack': 'ca',
-                'carmen:center': [ 0, 0 ]
+                'carmen:center': [ 0, 0 ],
+                accuracy: 'intersection'
             },
             geometry: {
                 type: 'Point',
@@ -73,7 +74,8 @@ test('Intersections - Synonyms', async(t) => {
             properties: {
                 'carmen:text': 'Main Street and 1st Avenue,1st Avenue and Main Street,US Highway 2 and 1st Avenue,1st Avenue and US Highway 2',
                 'carmen:geocoder_stack': 'ca',
-                'carmen:center': [ 0, 0 ]
+                'carmen:center': [ 0, 0 ],
+                accuracy: 'intersection'
             },
             geometry: {
                 type: 'Point',


### PR DESCRIPTION
Add `accuracy: intersection` to easily allow differentiation between intersection & address cluster output.