### PR TITLE
Cardinal skip

### DIFF
--- a/lib/post/cardinality.js
+++ b/lib/post/cardinality.js
@@ -17,19 +17,22 @@ function post(feat) {
     let preRegex = /^(south|s|north|n|east|e|west|w|southeast|se|southwest|sw|northeast|ne|northwest|nw)\s/i;
 
     for (let t of texts) {
+        if (t.match(postRegex) && t.match(preRegex)) {
+            // S Main NW
 
-        //Main W => W Main,Main
-        if (t.match(postRegex)) {
+            continue;
+        } else if (t.match(postRegex)) {
+            //Main W => W Main,Main
+
             let cardinal = t.match(postRegex);
             let name = t.replace(postRegex, '');
             let syn = `${cardinal[0]} ${name}`.trim();
 
             if (texts.indexOf(syn) === -1) texts.push(syn);
             if (texts.indexOf(name) === -1) texts.push(name);
-        }
+        } else if (t.match(preRegex)) {
+            //W Main => Main W,Main
 
-        //W Main => Main W,Main
-        if (t.match(preRegex)) {
             let cardinal = t.match(preRegex);
             let name = t.replace(preRegex, '');
             let syn = `${name} ${cardinal[0]}`.trim();

--- a/test/post.cardinality.test.js
+++ b/test/post.cardinality.test.js
@@ -16,6 +16,10 @@ test('Post: Cardinality', (t) => {
     t.equals(f('South Main St'), 'South Main St,Main St South,Main St');
     t.equals(f('Main St South'), 'Main St South,South Main St,Main St');
 
+
+    t.equals(f('S Main St NW'), 'S Main St NW');
+    t.equals(f('NW Main St S'), 'NW Main St S');
+
     t.equals(f('South Main St,Fake St South'), 'South Main St,Fake St South,Main St South,Main St,South Fake St,Fake St');
 
     //Random Sample From SG File


### PR DESCRIPTION
Don't create cardinality synonyms if there is a preCardinal and a postCardinal in the text.

Example:
![screenshot from 2019-02-04 09-33-32](https://user-images.githubusercontent.com/1297009/52226912-0eff5a80-2863-11e9-8845-28eb3acec7a6.png)
