### PR TITLE
Ensure quotes are removed from display

### DIFF
--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -134,8 +134,10 @@ impl Name {
     /// * `display` - A string containing the street name (Main St)
     ///
     /// ```
-    pub fn new(display: String, priority: i8, context: &Context) -> Self {
+    pub fn new(mut display: String, priority: i8, context: &Context) -> Self {
         let tokens = context.tokens.process(&display);
+
+        display = display.replace(r#"""#, "");
 
         Name {
             display: display,


### PR DESCRIPTION
OpenAddresses Belgium data has quotes in display name, causing postgres to get a bit testy on import