### PR TITLE
Better escape

### DIFF
--- a/native/src/pg/mod.rs
+++ b/native/src/pg/mod.rs
@@ -61,8 +61,12 @@ impl Table for Address {
                 geom
             )
             FROM STDIN
-            WITH
-                NULL AS ''
+            WITH (
+                FORMAT CSV,
+                NULL '',
+                DELIMITER E'\t',
+                QUOTE E'\b'
+            )
         "#).as_str()).unwrap();
 
         stmt.copy_in(&[], &mut data).unwrap();
@@ -145,7 +149,21 @@ impl Table for Network {
     }
 
     fn input(conn: &Connection, mut data: impl Read) {
-        let stmt = conn.prepare(format!("COPY network (names, source, props, geom) FROM STDIN").as_str()).unwrap();
+        let stmt = conn.prepare(format!(r#"
+            COPY network (
+                names,
+                source,
+                props,
+                geom
+            )
+            FROM STDIN
+            WITH (
+                FORMAT CSV,
+                NULL '',
+                DELIMITER E'\t',
+                QUOTE E'\b'
+            )
+        "#).as_str()).unwrap();
 
         stmt.copy_in(&[], &mut data).unwrap();
     }

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -139,7 +139,7 @@ impl Name {
 
         display = display
             .replace(r#"""#, "")
-            .replace(r#"\"#, "")
+            .replace("\t", "")
             .replace("\n", "");
 
         Name {


### PR DESCRIPTION
The `CSV` Format of PG Copy has far better behavior for sensible escaping in JSON data.