### PR TITLE
Assign 0 to z position if null

### DIFF
--- a/native/src/pg/mod.rs
+++ b/native/src/pg/mod.rs
@@ -92,7 +92,7 @@ impl Table for Address {
             ALTER TABLE address
                 ALTER COLUMN geom
                 TYPE GEOMETRY(POINTZ, 4326)
-                USING ST_SetSRID(ST_MakePoint(ST_X(geom), ST_Y(geom), id::FLOAT), 4326);
+                USING ST_SetSRID(ST_MakePoint(ST_X(geom), ST_Y(geom), COALESCE(id::FLOAT, 0)), 4326);
         "#, &[]).unwrap();
 
         conn.execute(r#"


### PR DESCRIPTION
Fix https://github.com/ingalls/pt2itp/issues/408

If the z position to generate points is null, the geometry is null, since this value depends on the `id` property, if `id` is null or a string, the geometry of the feature it is null too.

[`SELECT ST_MakePoint(1.1, 1.1, id::FLOAT);`](https://github.com/ingalls/pt2itp/blob/master/native/src/pg/mod.rs#L95)

This PR add the function COALESCE, to assign 0 to the z position of it is null

:heavy_check_mark: I tested it with the same case in https://github.com/ingalls/pt2itp/issues/408

@ingalls 