### PR TITLE
Faster Orphan Query

### DIFF
--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -86,8 +86,6 @@ class Orphan {
                     ) a
                     group by id, name, geom`;
 
-                let cursor;
-
                 client.query('BEGIN', (err) => {
                     if (shouldAbort(err)) return cb(err);
                     client.query(createJoinTable, (err, res) => {
@@ -98,8 +96,8 @@ class Orphan {
                                 if (shouldAbort(err)) return cb(err);
                                 client.query('COMMIT', (err) => {
                                     if (err) return cb(err);
-                                    cursor = client.query(selectOrphans);
-                                    return iterate();
+                                    const cursor = client.query(selectOrphans);
+                                    return iterate(cursor);
                                 });
                             });
                         });
@@ -109,7 +107,7 @@ class Orphan {
                 /**
                  * Iterate over unmatched address clusters using PG Cursor to avoid memory over utilization
                  */
-                function iterate() {
+                function iterate(cursor) {
                     cursor.read(1000, (err, rows) => {
                         if (err) return cb(err);
 
@@ -158,7 +156,7 @@ class Orphan {
                             }
                         });
 
-                        return iterate();
+                        return iterate(cursor);
                     });
                 }
             });

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -44,6 +44,7 @@ class Orphan {
                     return !!err
                 }
 
+                const dropJoinTable = 'DROP TABLE IF EXISTS address_orphan_cluster_id_to_z';
                 const createJoinTable = `
                     CREATE TABLE IF NOT EXISTS address_orphan_cluster_id_to_z as
                     SELECT
@@ -86,18 +87,22 @@ class Orphan {
                     ) a
                     group by id, name, geom`;
 
+                let cursor;
                 client.query('BEGIN', (err) => {
                     if (shouldAbort(err)) return cb(err);
-                    client.query(createJoinTable, (err, res) => {
+                    client.query(dropJoinTable, (err, res) => {
                         if (shouldAbort(err)) return cb(err);
-                        client.query(createJoinTableIdIndex, (err, res) => {
+                        client.query(createJoinTable, (err, res) => {
                             if (shouldAbort(err)) return cb(err);
-                            client.query(createJoinTableZIndex, (err, res) => {
+                            client.query(createJoinTableIdIndex, (err, res) => {
                                 if (shouldAbort(err)) return cb(err);
-                                client.query('COMMIT', (err) => {
-                                    if (err) return cb(err);
-                                    const cursor = client.query(new Cursor(selectOrphans));
-                                    return iterate(cursor);
+                                client.query(createJoinTableZIndex, (err, res) => {
+                                    if (shouldAbort(err)) return cb(err);
+                                    client.query('COMMIT', (err) => {
+                                        if (err) return cb(err);
+                                        cursor = client.query(new Cursor(selectOrphans));
+                                        return iterate();
+                                    });
                                 });
                             });
                         });
@@ -107,7 +112,7 @@ class Orphan {
                 /**
                  * Iterate over unmatched address clusters using PG Cursor to avoid memory over utilization
                  */
-                function iterate(cursor) {
+                function iterate() {
                     cursor.read(1000, (err, rows) => {
                         if (err) return cb(err);
 
@@ -156,7 +161,7 @@ class Orphan {
                             }
                         });
 
-                        return iterate(cursor);
+                        return iterate();
                     });
                 }
             });

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -66,7 +66,7 @@ class Orphan {
                     from
                     (
                     SELECT
-                        address_orphan_cluster.id,
+                        address.id,
                         address_orphan_cluster.name,
                         address_orphan_cluster.geom,
                         json_build_object(

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -30,19 +30,19 @@ class Orphan {
             this.pool.connect((err, client, done) => {
                 if (err) return cb(err);
 
-		const shouldAbort = (err) => {
-		    if (err) {
-		        console.error('Error in transaction', err.stack)
-		        client.query('ROLLBACK', (err) => {
-		            if (err) {
-		                console.error('Error rolling back client', err.stack)
-		            }
-		                // release the client back to the pool
-		                done()
-		            })
-		    }
-		    return !!err
-		}
+                const shouldAbort = (err) => {
+                    if (err) {
+                        console.error('Error in transaction', err.stack)
+                        client.query('ROLLBACK', (err) => {
+                            if (err) {
+                                console.error('Error rolling back client', err.stack)
+                            }
+                                // release the client back to the pool
+                                done()
+                            })
+                    }
+                    return !!err
+                }
 
                 const createJoinTable = `
                     CREATE TABLE IF NOT EXISTS address_orphan_cluster_id_to_z as

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -60,7 +60,6 @@ class Orphan {
                     on address_orphan_cluster_id_to_z (z);`;
                 const selectOrphans = `
                     Select
-                        id,
                         name,
                         ST_AsGeoJSON(geom)::JSON AS geom,
                         json_agg(props) as props
@@ -85,7 +84,7 @@ class Orphan {
                         address
                                 on (address.id = address_orphan_cluster_id_to_z.z)
                     ) a
-                    group by id, name, geom`;
+                    group by name, geom`;
 
                 let cursor;
                 client.query('BEGIN', (err) => {

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -99,13 +99,12 @@ class Orphan {
                                 client.query('COMMIT', (err) => {
                                     if (err) return cb(err);
                                     cursor = client.query(selectOrphans);
+                                    return iterate();
                                 });
                             });
                         });
                     });
                 });
-
-                return iterate();
 
                 /**
                  * Iterate over unmatched address clusters using PG Cursor to avoid memory over utilization

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -105,6 +105,7 @@ class Orphan {
                     });
                 });
 
+                return iterate();
 
                 /**
                  * Iterate over unmatched address clusters using PG Cursor to avoid memory over utilization

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -31,34 +31,42 @@ class Orphan {
                 if (err) return cb(err);
 
                 const cursor = client.query(new Cursor(`
+                    create table aoc_id_to_z as
                     SELECT
-                        name AS name,
+                         id,
+                         ST_Z((ST_Dump(geom)).geom)::bigint as z
+                    from address_orphan_cluster;
+
+                    create index aoc_id_to_z__id on aoc_id_to_z (id);
+                    create index aoc_id_to_z__z on aoc_id_to_z (z);
+
+
+                    EXPLAIN ANALYZE
+                    Select
+                        id,
+                        name,
                         ST_AsGeoJSON(geom)::JSON AS geom,
-                        (
-                            SELECT
-                                json_agg(json_build_object(
-                                     'id', r.id,
-                                     'number', r.number,
-                                     'props', r.props,
-                                     'output', r.output
-                                ))
-                            FROM (
-                                SELECT
-                                    a.id AS id,
-                                    address.number AS number,
-                                    address.props AS props,
-                                    address.output as output
-                                FROM
-                                    (
-                                        SELECT ST_Z((ST_Dump(address_orphan_cluster.geom)).geom) AS id
-                                    ) a,
-                                    address
-                                WHERE
-                                    a.id = address.id
-                            ) r
+                        json_agg(props) as props
+                    from
+                    (
+                    SELECT
+                        address_orphan_cluster.id,
+                        address_orphan_cluster.name,
+                        address_orphan_cluster.geom,
+                        json_build_object(
+                            'id', address.id,
+                            'number', address.number,
+                            'props', address.props,
+                            'output', address.output
                         ) as props
                     FROM
-                        address_orphan_cluster;
+                        address_orphan_cluster
+                            join
+                        aoc_id_to_z on (address_orphan_cluster.id = aoc_id_to_z.id)
+                            join
+                        address on (address.id = aoc_id_to_z.z)
+                    ) a
+                    group by id, name, geom;
                 `));
 
                 return iterate();

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -96,7 +96,7 @@ class Orphan {
                                 if (shouldAbort(err)) return cb(err);
                                 client.query('COMMIT', (err) => {
                                     if (err) return cb(err);
-                                    const cursor = client.query(selectOrphans);
+                                    const cursor = client.query(new Cursor(selectOrphans));
                                     return iterate(cursor);
                                 });
                             });

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -40,8 +40,6 @@ class Orphan {
                     create index aoc_id_to_z__id on aoc_id_to_z (id);
                     create index aoc_id_to_z__z on aoc_id_to_z (z);
 
-
-                    EXPLAIN ANALYZE
                     Select
                         id,
                         name,

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -30,16 +30,34 @@ class Orphan {
             this.pool.connect((err, client, done) => {
                 if (err) return cb(err);
 
-                const cursor = client.query(new Cursor(`
-                    create table aoc_id_to_z as
+		const shouldAbort = (err) => {
+		    if (err) {
+		        console.error('Error in transaction', err.stack)
+		        client.query('ROLLBACK', (err) => {
+		            if (err) {
+		                console.error('Error rolling back client', err.stack)
+		            }
+		                // release the client back to the pool
+		                done()
+		            })
+		    }
+		    return !!err
+		}
+
+                const createJoinTable = `
+                    CREATE TABLE IF NOT EXISTS address_orphan_cluster_id_to_z as
                     SELECT
-                         id,
-                         ST_Z((ST_Dump(geom)).geom)::bigint as z
-                    from address_orphan_cluster;
-
-                    create index aoc_id_to_z__id on aoc_id_to_z (id);
-                    create index aoc_id_to_z__z on aoc_id_to_z (z);
-
+                        id,
+                        ST_Z((ST_Dump(geom)).geom)::bigint AS z
+                    FROM
+                        address_orphan_cluster`;
+                const createJoinTableIdIndex = `
+                    create index if not exists address_orphan_cluster_id_to_z__id
+                    on address_orphan_cluster_id_to_z (id);`;
+                const createJoinTableZIndex = `
+                    create index if not exists address_orphan_cluster_id_to_z__z
+                    on address_orphan_cluster_id_to_z (z);`;
+                const selectOrphans = `
                     Select
                         id,
                         name,
@@ -60,14 +78,33 @@ class Orphan {
                     FROM
                         address_orphan_cluster
                             join
-                        aoc_id_to_z on (address_orphan_cluster.id = aoc_id_to_z.id)
+                        address_orphan_cluster_id_to_z
+                                on (address_orphan_cluster.id = address_orphan_cluster_id_to_z.id)
                             join
-                        address on (address.id = aoc_id_to_z.z)
+                        address
+                                on (address.id = address_orphan_cluster_id_to_z.z)
                     ) a
-                    group by id, name, geom;
-                `));
+                    group by id, name, geom`;
 
-                return iterate();
+                let cursor;
+
+                client.query('BEGIN', (err) => {
+                    if (shouldAbort(err)) return cb(err);
+                    client.query(createJoinTable, (err, res) => {
+                        if (shouldAbort(err)) return cb(err);
+                        client.query(createJoinTableIdIndex, (err, res) => {
+                            if (shouldAbort(err)) return cb(err);
+                            client.query(createJoinTableZIndex, (err, res) => {
+                                if (shouldAbort(err)) return cb(err);
+                                client.query('COMMIT', (err) => {
+                                    if (err) return cb(err);
+                                    cursor = client.query(selectOrphans);
+                                });
+                            });
+                        });
+                    });
+                });
+
 
                 /**
                  * Iterate over unmatched address clusters using PG Cursor to avoid memory over utilization


### PR DESCRIPTION
heads-up: the diff is really hard to read.  it's a wholesale replacement of the query.

also, i just slapped this query into the approximate place because i needed to sign off and wanted to push my WIP. needs adjustment.

This PR adds a more efficient orphan query.  Although `EXPLAIN` estimates that it will take much longer than the old query, the actual execution time is much less.

| | estimated `cost` | actual time |
|---|---:|---|
| old query | `218,368,249,891` | (currently 15 hours and counting) |
| new query | `5,791,526,544,027` | 29m28s |

new query `EXPLAIN ANALYZE` results:

```
                                                                                                  QUERY PLAN

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------------------------------
 GroupAggregate  (cost=5791526544027.96..5899744566407.62 rows=1688400 width=136) (actual time=13699.483..1580810.319 rows=484707 loops=1)
   Group Key: address.id, address_orphan_cluster.name, address_orphan_cluster.geom
   ->  Sort  (cost=5791526544027.96..5809562172666.73 rows=7214251455511 width=137) (actual time=13699.348..14285.206 rows=484707 loops=1)
         Sort Key: address.id, address_orphan_cluster.name, address_orphan_cluster.geom
         Sort Method: external sort  Disk: 533856kB
         ->  Merge Join  (cost=1.15..108220882087.34 rows=7214251455511 width=137) (actual time=0.088..12537.940 rows=484707 loops=1)
               Merge Cond: (address.id = address_orphan_cluster_id_to_z.z)
               ->  Index Scan using address_id_plain on address  (cost=0.43..1287848.16 rows=7051982 width=73) (actual time=0.014..5003.708 rows=7050527 loops=1)
               ->  Materialize  (cost=0.71..6316281.80 rows=204602095 width=72) (actual time=0.049..3229.375 rows=484707 loops=1)
                     ->  Nested Loop  (cost=0.71..5804776.56 rows=204602095 width=72) (actual time=0.044..2654.654 rows=484707 loops=1)
                           ->  Index Scan using address_orphan_cluster_id_to_z__z on address_orphan_cluster_id_to_z  (cost=0.42..23083.03 rows=484707 width=12) (actual time=0.030..422.135 rows=484707 loops=1)
                           ->  Index Scan using address_orphan_cluster_id_idx on address_orphan_cluster  (cost=0.29..7.71 rows=422 width=68) (actual time=0.002..0.002 rows=1 loops=484707)
                                 Index Cond: (id = address_orphan_cluster_id_to_z.id)
 Planning time: 0.539 ms
 Execution time: 1581215.354 ms
(15 rows)```