### PR TITLE
allowing conflate when `street` is a string

### DIFF
--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -197,6 +197,10 @@ class Compare {
             return turf.distance(new_address, row.feat.geometry, { units: 'kilometers' }) < 0.5;
         });
 
+        if (!Array.isArray(new_address.properties.street)) {
+            new_address.properties.street = [{ display: new_address.properties.street, priority: 0 }];
+        }
+
         const potentials = new_address.properties.street.map((name) => {
             return tokenize.replaceToken(tokenRegex, tokenize.main(name.display, this.opts.tokens, true).tokens.join(' '));
         });


### PR DESCRIPTION
This is a small fix to the conflate script, which expects the new address data to have `street` properties like:

```
properties: {
    number: "123",
    street: [{ display: "Main Street",  priority: 0 }]
}
```

Whereas some of our source data has a simple string for `street`, like: 

```
properties : {
    number: "123",
    street: "Main Street"
}
```