### PR TITLE
Stable Sort Order

### DIFF
--- a/lib/map/post.js
+++ b/lib/map/post.js
@@ -2,13 +2,13 @@ const fs = require('fs');
 
 const defaults = [ //Mandatory Steps
     require('../post/intersections').post,
-    require('../post/props').post,
     require('../post/id').post,
     require('../post/text').post,
     require('../post/dedupe-address').post,
     require('../post/sort').post,
     require('../post/centre').post,
-    require('../post/internal').post
+    require('../post/internal').post,
+    require('../post/props').post
 ];
 
 /**

--- a/lib/post/dedupe-address.js
+++ b/lib/post/dedupe-address.js
@@ -8,6 +8,10 @@ function post(feat) {
     if (!Array.isArray(feat.properties['carmen:addressnumber'])) return feat;
     if (!feat.geometry || !feat.geometry.geometries || !feat.geometry.geometries.length) return feat;
 
+    if (feat.properties['carmen:addressprops'] && !Array.isArray(feat.properties['carmen:addressprops'])) {
+        throw new Error('sort must be run before props post script');
+    }
+
     for (let i = 0; i < feat.properties['carmen:addressnumber'].length; i++) {
         if (!Array.isArray(feat.properties['carmen:addressnumber'][i])) continue;
 

--- a/lib/post/dedupe-address.js
+++ b/lib/post/dedupe-address.js
@@ -8,7 +8,7 @@ function post(feat) {
     if (!Array.isArray(feat.properties['carmen:addressnumber'])) return feat;
     if (!feat.geometry || !feat.geometry.geometries || !feat.geometry.geometries.length) return feat;
 
-    if (feat.properties['carmen:addressprops'] && !Array.isArray(feat.properties['carmen:addressprops'])) {
+    if (feat.properties['carmen:addressprops']) {
         throw new Error('sort must be run before props post script');
     }
 

--- a/lib/post/dedupe-address.js
+++ b/lib/post/dedupe-address.js
@@ -9,7 +9,9 @@ function post(feat) {
     if (!feat.geometry || !feat.geometry.geometries || !feat.geometry.geometries.length) return feat;
 
     if (feat.properties['carmen:addressprops']) {
-        throw new Error('sort must be run before props post script');
+        throw new Error('dedupe must be run before props post script');
+    } else if (!feat.properties.address_props) {
+        feat.properties.address_props = [];
     }
 
     for (let i = 0; i < feat.properties['carmen:addressnumber'].length; i++) {
@@ -17,6 +19,7 @@ function post(feat) {
 
         const number = [];
         const coords = [];
+        const props = [];
 
         for (let j = 0; j < feat.properties['carmen:addressnumber'][i].length; j++) {
             if (!feat.properties['carmen:addressnumber'][i][j]) continue;
@@ -24,11 +27,13 @@ function post(feat) {
             if (number.indexOf(feat.properties['carmen:addressnumber'][i][j]) === -1) {
                 number.push(feat.properties['carmen:addressnumber'][i][j]);
                 coords.push(feat.geometry.geometries[i].coordinates[j]);
+                props.push(feat.properties.address_props[j] ? feat.properties.address_props[j] : {});
             }
         }
 
         feat.properties['carmen:addressnumber'][i] = number;
         feat.geometry.geometries[i].coordinates = coords;
+        feat.properties.address_props = props;
 
         if (feat.properties['carmen:addressnumber'][i].length === 0) {
             delete feat.properties['carmen:addressnumber'];

--- a/lib/post/sort.js
+++ b/lib/post/sort.js
@@ -8,6 +8,10 @@ const _ = require('lodash');
 function post(feat) {
     if (!feat || !feat.properties || !feat.properties['carmen:addressnumber']) return feat;
 
+    if (feat.properties['carmen:addressprops'] && !Array.isArray(feat.properties['carmen:addressprops'])) {
+        throw new Error('sort must be run before props post script');
+    }
+
     for (let i = 0; i < feat.properties['carmen:addressnumber'].length; i++) {
         if (!feat.properties['carmen:addressnumber'][i] && !Array.isArray(feat.properties['carmen:addressnumber'][i])) continue;
 

--- a/lib/post/sort.js
+++ b/lib/post/sort.js
@@ -8,26 +8,38 @@ const _ = require('lodash');
 function post(feat) {
     if (!feat || !feat.properties || !feat.properties['carmen:addressnumber']) return feat;
 
-    if (feat.properties['carmen:addressprops'] && !Array.isArray(feat.properties['carmen:addressprops'])) {
+    if (feat.properties['carmen:addressprops'] {
         throw new Error('sort must be run before props post script');
     }
 
     for (let i = 0; i < feat.properties['carmen:addressnumber'].length; i++) {
         if (!feat.properties['carmen:addressnumber'][i] && !Array.isArray(feat.properties['carmen:addressnumber'][i])) continue;
 
-        let nums = _.cloneDeep(feat.properties['carmen:addressnumber'][i]);
-        let crds = [];
-
-        nums.sort((a, b) => {
-            return a - b;
-        });
-
-        for (let num of nums) {
-            crds.push(feat.geometry.geometries[i].coordinates[feat.properties['carmen:addressnumber'][i].indexOf(num)]);
+        // Convert to easily sortable array
+        let sortable = [];
+        for (let addr_it = 0; addr_it < feat.properties['carmen:addressnumber'][i].length; addr_it++) {
+            sortable.push({
+                num: feat.properties['carmen:addressnumber'][i][addr_it],
+                coord: feat.geometry.geometries[i].coordinates[addr_it],
+                props: feat.address_props[addr_it]
+            });
         }
 
-        feat.properties['carmen:addressnumber'][i] = nums;
-        feat.geometry.geometries[i].coordinates = crds;
+        sortable.sort((a, b) => {
+            return a.num - b.num;
+        });
+
+        feat.properties['carmen:addressnumber'][i] = sortable.map((s) => {
+            return s.num;
+        });
+
+        feat.properties.address_props = sortable.map((s) => {
+            return s.props;
+        });
+
+        feat.geometry..geometries[i].coordinates = sortable.map((s) => {
+            return s.coord;
+        });
     }
 
     return feat;

--- a/lib/post/sort.js
+++ b/lib/post/sort.js
@@ -8,8 +8,10 @@ const _ = require('lodash');
 function post(feat) {
     if (!feat || !feat.properties || !feat.properties['carmen:addressnumber']) return feat;
 
-    if (feat.properties['carmen:addressprops'] {
+    if (feat.properties['carmen:addressprops']) {
         throw new Error('sort must be run before props post script');
+    } else if (!feat.properties.address_props) {
+        feat.properties.address_props = [];
     }
 
     for (let i = 0; i < feat.properties['carmen:addressnumber'].length; i++) {
@@ -21,7 +23,7 @@ function post(feat) {
             sortable.push({
                 num: feat.properties['carmen:addressnumber'][i][addr_it],
                 coord: feat.geometry.geometries[i].coordinates[addr_it],
-                props: feat.address_props[addr_it]
+                props: feat.properties.address_props[addr_it] ? feat.properties.address_props[addr_it] : {}
             });
         }
 
@@ -37,7 +39,7 @@ function post(feat) {
             return s.props;
         });
 
-        feat.geometry..geometries[i].coordinates = sortable.map((s) => {
+        feat.geometry.geometries[i].coordinates = sortable.map((s) => {
             return s.coord;
         });
     }

--- a/test/post.dedupe-address.test.js
+++ b/test/post.dedupe-address.test.js
@@ -71,7 +71,8 @@ test('Post: Dedupe', (t) => {
         }
     }), {
         properties: {
-            'carmen:addressnumber': [[1]]
+            'carmen:addressnumber': [[1]],
+            address_props: [{}]
         },
         geometry: {
             geometries: [{
@@ -91,7 +92,8 @@ test('Post: Dedupe', (t) => {
         }
     }), {
         properties: {
-            'carmen:addressnumber': [[ 1, 2, 3, 4 ]]
+            'carmen:addressnumber': [[ 1, 2, 3, 4 ]],
+            address_props: [ {}, {}, {}, {} ]
         },
         geometry: {
             geometries: [{
@@ -111,7 +113,54 @@ test('Post: Dedupe', (t) => {
         }
     }), {
         properties: {
-            'carmen:addressnumber': [[ 1, 2, 3, 4 ]]
+            'carmen:addressnumber': [[ 1, 2, 3, 4 ]],
+            address_props: [{}, {}, {}, {}]
+        },
+        geometry: {
+            geometries: [{
+                coordinates: [[1,1], [2,2], [3,3], [4,4]]
+            }]
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[ 1, 2, 3, 4, 1, 2, 3, 4 ]],
+            address_props: [{
+                element: 0
+            },{
+                element: 1
+            },{
+                element: 2
+            },{
+                element: 3
+            },{
+                element: 4
+            },{
+                element: 5
+            },{
+                element: 6
+            },{
+                element: 7
+            }]
+        },
+        geometry: {
+            geometries: [{
+                coordinates: [[1,1], [2,2], [3,3], [4,4], [1,1], [2,2], [3,3], [4,4]]
+            }]
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[ 1, 2, 3, 4 ]],
+            address_props: [{
+                element: 0
+            }, {
+                element: 1
+            }, {
+                element: 2
+            }, {
+                element: 3
+            }]
         },
         geometry: {
             geometries: [{

--- a/test/post.sort.test.js
+++ b/test/post.sort.test.js
@@ -21,7 +21,8 @@ test('Post: Sort', (t) => {
         }
     }), {
         properties: {
-            'carmen:addressnumber': [ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ]
+            'carmen:addressnumber': [ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ],
+            address_props: [{},{},{},{},{},{},{},{},{},{}]
         },
         geometry: {
             geometries: [{
@@ -41,7 +42,70 @@ test('Post: Sort', (t) => {
         }
     }), {
         properties: {
-            'carmen:addressnumber': [ null, [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ]
+            'carmen:addressnumber': [ null, [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ],
+            address_props: [{},{},{},{},{},{},{},{},{},{}]
+        },
+        geometry: {
+            geometries: [null, {
+                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7],[8,8],[9,9],[10,10]]
+            }]
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [null, [10,9,8,7,6,5,4,3,2,1]],
+            address_props: [{
+                number: 10,
+            },{
+                number: 9,
+            },{
+                number: 8,
+            },{
+                number: 7,
+            },{
+                number: 6,
+            },{
+                number: 5,
+            },{
+                number: 4,
+            },{
+                number: 3,
+            },{
+                number: 2,
+            },{
+                number: 1
+            }]
+        },
+        geometry: {
+            geometries: [null, {
+                coordinates: [[10,10],[9,9],[8,8],[7,7],[6,6],[5,5],[4,4],[3,3],[2,2],[1,1]]
+            }]
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [ null, [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ],
+            address_props: [{
+                number: 1
+            },{
+                number: 2
+            },{
+                number: 3
+            },{
+                number: 4
+            },{
+                number: 5
+            },{
+                number: 6
+            },{
+                number: 7
+            },{
+                number: 8
+            },{
+                number: 9
+            },{
+                number: 10
+            }]
         },
         geometry: {
             geometries: [null, {


### PR DESCRIPTION
After building & debugging the second build of address data that includes postcode overrides (https://github.com/mapbox/carmen/pull/840) I realized that the element order between the `carmen:addressnumber` & `carmen:addressprops` was not being respected.

Although `carmen:addressprops` has extensive tests around retaining order, the `sort` and `dedupe-address` post functions do not and are destructive to this element based ordering.

- [x] Add hard errors so if the order in which the post scripts are run is changed, pt2itp will hard fail as it will be unable to retain order through the function
- [x] Move the `props` post script to the last step as it is easier to maintain sort order via an Array instead of the `carmen:addressprops` format
- [x] Ensure order retention & assoc tests in `sort` post script
- [x] Ensure order retention & assoc tests in `dedupe-address` post script

cc @miccolis