### PR TITLE
Name Retention

### DIFF
--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -77,7 +77,16 @@ impl Address {
             None => { return Err(String::from("Addresses must have geometry")); }
         };
 
-        let mut names = Names::from_value(props.remove(&String::from("street")), &context)?;
+        let street = match props.remove(&String::from("street")) {
+            Some(street) => {
+                props.insert(String::from("street"), street.clone());
+
+                Some(street)
+            },
+            None => None
+        };
+
+        let mut names = Names::from_value(street, &context)?;
 
         names.set_source(String::from("address"));
 
@@ -110,8 +119,10 @@ impl Address {
             _ => { return Err(String::from("Address::from_row value must be JSON Object")); }
         };
 
-        let names: Names = match value.remove(&String::from("names")) {
+        let names: Names = match value.get(&String::from("names")) {
             Some(names) => {
+                let names = names.clone();
+
                 let names: Vec<Name> = match serde_json::from_value(names) {
                     Ok(names) => names,
                     Err(err) => { return Err(format!("Names Conversion Error: {}", err.to_string())); }
@@ -277,8 +288,8 @@ fn get_id(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<Option
 }
 
 fn get_number(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<String, String> {
-    match map.remove(&String::from("number")) {
-        Some(number) => match number {
+    match map.get(&String::from("number")) {
+        Some(number) => match number.clone() {
             serde_json::value::Value::Number(num) => {
                 Ok(String::from(num.to_string()))
             },
@@ -302,8 +313,8 @@ fn get_version(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<i
 }
 
 fn get_source(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<String, String> {
-    match map.remove(&String::from("source")) {
-        Some(source) => match source {
+    match map.get(&String::from("source")) {
+        Some(source) => match source.clone() {
             serde_json::value::Value::String(source) => Ok(source),
             _ => Ok(String::from(""))
         },

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -8,7 +8,7 @@ use crate::{Context, text, Names};
 pub struct Network {
     /// An optional identifier for the network
     pub id: Option<i64>,
-    
+
     /// Vector of all street name synonyms
     pub names: super::Names,
 
@@ -34,8 +34,9 @@ impl Network {
             None => { return Err(String::from("Feature has no properties")); }
         };
 
-        let source = match props.remove(&String::from("source")) {
+        let source = match props.get(&String::from("source")) {
             Some(source) => {
+                let source = source.clone();
                 if source.is_string() {
                     String::from(source.as_str().unwrap())
                 } else {
@@ -54,7 +55,17 @@ impl Network {
             None => { return Err(String::from("Network must have geometry")); }
         };
 
-        let mut names = Names::from_value(props.remove(&String::from("street")), &context)?;
+
+        let street = match props.remove(&String::from("street")) {
+            Some(street) => {
+                props.insert(String::from("street"), street.clone());
+
+                Some(street)
+            },
+            None => None
+        };
+
+        let mut names = Names::from_value(street, &context)?;
 
         names.set_source(String::from("network"));
 

--- a/test/classify.test.js
+++ b/test/classify.test.js
@@ -72,23 +72,128 @@ test('classify (hecate)', (t) => {
 
     t.deepEquals(output[0], undefined);
 
-    t.deepEquals(output[1].properties.accuracy, output[1].properties.expected);
+    t.deepEquals(output[1], {
+        id: 1,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'rooftop',
+            expected: 'rooftop',
+            number: 1,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.3766257166862, 38.8341710657445 ]
+        }
+    });
 
     t.deepEquals(output[2], undefined);
 
-    t.deepEquals(output[3].properties.accuracy, output[3].properties.expected);
+    t.deepEquals(output[3], {
+        id: 3,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'rooftop',
+            expected: 'rooftop',
+            number: 3,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.3770414590836, 38.8339495948735 ]
+        }
+    });
 
-    t.deepEquals(output[4].properties.accuracy, output[4].properties.expected);
+    t.deepEquals(output[4], {
+        id: 4,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'rooftop',
+            expected: 'rooftop',
+            number: 4,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.3768778443336, 38.8344489480323 ]
+        }
+    });
 
-    t.deepEquals(output[5].properties.accuracy, output[5].properties.expected);
+    t.deepEquals(output[5], {
+        id: 5,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'rooftop',
+            expected: 'rooftop',
+            number: 5,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.3768563866615, 38.8343779105582 ]
+        }
+    });
 
     t.deepEquals(output[6], undefined);
 
-    t.deepEquals(output[7].properties.accuracy, output[7].properties.expected);
+    t.deepEquals(output[7], {
+        id: 7,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'parcel',
+            expected: 'parcel',
+            number: 7,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.3765304982662, 38.8336497715408 ]
+        }
+    });
 
-    t.deepEquals(output[8].properties.accuracy, output[8].properties.expected);
+    t.deepEquals(output[8], {
+        id: 8,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'point',
+            expected: 'point',
+            number: 8,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.4051456451416, 38.8391059265703 ]
+        }
+    });
 
-    t.deepEquals(output[9].properties.accuracy, output[9].properties.expected);
+    t.deepEquals(output[9], {
+        id: 9,
+        version: 0,
+        type: 'Feature',
+        action: 'modify',
+        properties: {
+            accuracy: 'point',
+            expected: 'point',
+            number: 9,
+            street: 'Main St'
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [ -79.4054889678955, 38.8344259653278 ]
+        }
+    });
 
     t.end();
 });

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -54,7 +54,8 @@ test('dedupe (dataset)', (t) => {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
             source: 'openaddresses',
-            random: 'property'
+            random: 'property',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -68,7 +69,8 @@ test('dedupe (dataset)', (t) => {
         properties: {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
-            source: 'random'
+            source: 'random',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -80,9 +82,10 @@ test('dedupe (dataset)', (t) => {
         id: 4,
         type: 'Feature',
         properties: {
-             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
+            names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
-            source: 'random'
+            source: 'random',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -96,7 +99,8 @@ test('dedupe (dataset)', (t) => {
         properties: {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
-            source: 'openaddresses'
+            source: 'openaddresses',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -110,7 +114,8 @@ test('dedupe (dataset)', (t) => {
         properties: {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123a',
-            source: 'rando'
+            source: 'rando',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -171,7 +176,8 @@ test('dedupe (hecate)', (t) => {
         properties: {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
-            source: 'random'
+            source: 'random',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -188,7 +194,8 @@ test('dedupe (hecate)', (t) => {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
             source: 'openaddresses',
-            random: 'property'
+            random: 'property',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',
@@ -205,7 +212,8 @@ test('dedupe (hecate)', (t) => {
             names: [ { display: 'Main St', freq: 1, priority: 0, source: 'address', tokenized: 'main st', tokenless: 'main st' } ],
             number: '123',
             source: 'openaddresses',
-            random: 'property'
+            random: 'property',
+            street: 'Main St'
         },
         geometry: {
             type: 'Point',


### PR DESCRIPTION
Names are currently mapped on input to the internal PT2ITP name format. For processes that are not expected to output modified data (instead outputting a new product) this is the simpler behavior.

However when generating data for reimport to a Hecate data server - the name fields should retain their original form if they are not modified, otherwise they will be potentially rejected by the server for being out of schema.