### PR TITLE
Discard poor quality orphan address clusters

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -86,6 +86,8 @@ module.exports = function(argv) {
             console.log('   --post <cardinality>,...        [optional] Optional PostProcessing Steps');
             console.log('          cardinality                  Add cardinal prefix/postfix as synonyms');
             console.log('                                         ie: Main St S => Main St S,S Main St');
+            console.log('          discard-bad-orphans          Discard orphan address clusters with only one address and only numeric,');
+            console.log('                                       only punctuation carmen:text, or no override:postcode property');
             console.log('   --tokens=<Code,Code,...>        [optional] Abbreviation tokens to match');
             console.log('   --props=<Prop,Prop,...>         [optional] List of properties to output that were included in');
             console.log('                                       the input GeoJSON');

--- a/lib/map.js
+++ b/lib/map.js
@@ -86,7 +86,7 @@ function main(argv, cb) {
     if (argv.post) {
         argv.post = argv.post.split(',');
         for (let p of argv.post) {
-            if (['cardinality'].indexOf(p) === -1) return cb(new Error(`unknown parameter '${p}' in --post flag`));
+            if (['cardinality', 'discard-bad-orphans'].indexOf(p) === -1) return cb(new Error(`unknown parameter '${p}' in --post flag`));
         }
     }
 

--- a/lib/map/post.js
+++ b/lib/map/post.js
@@ -55,7 +55,7 @@ class Post {
             f = post(f, this.opts);
         }
 
-        return f;
+        if (f) return f;
     }
 }
 

--- a/lib/post/discard-bad-orphans.js
+++ b/lib/post/discard-bad-orphans.js
@@ -1,0 +1,31 @@
+/**
+ * Exposes a post function to filter out orphan address clusters where:
+ * - there's only one address in the cluster
+ * - the 'carmen:text' is all numbers
+ * - the 'carmen:text' is all punctuation (based on standard punctuation for US-ASCII)
+ * - the feature doesn't contain a postcode property
+ * @param {Object} feat     GeoJSON Feature for examination
+ * @return {Object}         Output GeoJSON feature to write to output or false to drop feature
+ */
+function post(feat) {
+    if (feat &&
+        feat.properties &&
+        !feat.properties['carmen:rangetype'] &&
+        feat.properties['carmen:addressnumber'] &&
+        Array.isArray(feat.properties['carmen:addressnumber']) &&
+        Array.isArray(feat.properties['carmen:addressnumber'][0]) &&
+        feat.properties['carmen:addressnumber'][0].length === 1 &&
+        feat.properties['carmen:text'] &&
+        (typeof feat.properties['carmen:text'] === 'string')
+    ) {
+        const text = feat.properties['carmen:text'].trim();
+
+        if (!feat.properties.postcode ||
+            /^\d+$/.test(text) ||
+            (/^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/.test(text))
+        ) return false;
+    }
+    return feat;
+}
+
+module.exports.post = post;

--- a/lib/post/discard-bad-orphans.js
+++ b/lib/post/discard-bad-orphans.js
@@ -12,22 +12,18 @@ function post(feat) {
         feat.properties &&
         !feat.properties['carmen:rangetype'] &&
 
-        feat.properties['carmen:addressnumber'] &&
         Array.isArray(feat.properties['carmen:addressnumber']) &&
         Array.isArray(feat.properties['carmen:addressnumber'][0]) &&
         feat.properties['carmen:addressnumber'][0].length === 1 &&
 
-        feat.properties['carmen:text'] &&
         typeof feat.properties['carmen:text'] === 'string' &&
 
-        feat.properties.address_props &&
         Array.isArray(feat.properties.address_props)
     ) {
         const text = feat.properties['carmen:text'].trim();
 
-        if (feat.properties.address_props.length === 0 ||
-            (feat.properties.address_props[0] &&
-            !feat.properties.address_props[0]['override:postcode']) ||
+        if (!feat.properties.address_props.length >= 1 ||
+            !feat.properties.address_props[0]['override:postcode'] ||
             /^\d+$/.test(text) ||
             /^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/.test(text)
         ) return false;

--- a/lib/post/discard-bad-orphans.js
+++ b/lib/post/discard-bad-orphans.js
@@ -11,18 +11,25 @@ function post(feat) {
     if (feat &&
         feat.properties &&
         !feat.properties['carmen:rangetype'] &&
+
         feat.properties['carmen:addressnumber'] &&
         Array.isArray(feat.properties['carmen:addressnumber']) &&
         Array.isArray(feat.properties['carmen:addressnumber'][0]) &&
         feat.properties['carmen:addressnumber'][0].length === 1 &&
+
         feat.properties['carmen:text'] &&
-        (typeof feat.properties['carmen:text'] === 'string')
+        typeof feat.properties['carmen:text'] === 'string' &&
+
+        feat.properties.address_props &&
+        Array.isArray(feat.properties.address_props)
     ) {
         const text = feat.properties['carmen:text'].trim();
 
-        if (!feat.properties.postcode ||
+        if (feat.properties.address_props.length === 0 ||
+            (feat.properties.address_props[0] &&
+            !feat.properties.address_props[0]['override:postcode']) ||
             /^\d+$/.test(text) ||
-            (/^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/.test(text))
+            /^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/.test(text)
         ) return false;
     }
     return feat;

--- a/test/post.discard-bad-orphans.test.js
+++ b/test/post.discard-bad-orphans.test.js
@@ -64,14 +64,45 @@ test('Post: Discard Bad Orphans', (t) => {
     t.deepEquals(post({
         properties: {
             'carmen:addressnumber': [[1]],
+            'carmen:text': '1234',
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': '1234',
+        }
+    });
+
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            postcode: '20002'
+            address_props: ''
         }
     }), {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            postcode: '20002'
+            address_props: ''
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            address_props: [{
+                'override:postcode': '20002'
+            }]
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            address_props: [{
+                'override:postcode': '20002'
+            }]
         }
     });
 
@@ -79,7 +110,9 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': '1234',
-            postcode: '20002'
+            address_props: [{
+                'override:postcode': '20002'
+            }]
         }
     }), false);
 
@@ -87,7 +120,9 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': '_%^$*—',
-            postcode: '20002'
+            address_props: [{
+                'override:postcode': '20002'
+            }]
         }
     }), false);
 
@@ -95,6 +130,25 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
+            address_props: []
+        }
+    }), false);
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            address_props: [{}]
+        }
+    }), false);
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            address_props: [{
+                'override:postcode': null
+            }]
         }
     }), false);
 

--- a/test/post.discard-bad-orphans.test.js
+++ b/test/post.discard-bad-orphans.test.js
@@ -1,0 +1,102 @@
+const post = require('../lib/post/discard-bad-orphans').post;
+const test = require('tape');
+
+test('Post: Discard Bad Orphans', (t) => {
+    t.equals(post(), undefined);
+    t.deepEquals(post({}), {});
+    t.deepEquals(post({
+        properties: {}
+    }), {
+        properties: {}
+    });
+    t.deepEquals(post({
+        properties: {
+            'carmen:rangetype': 'tiger'
+        }
+    }), {
+        properties: {
+            'carmen:rangetype': 'tiger'
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': ''
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': ''
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': ['']
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': ['']
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1, 2, 3, 4]]
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[1, 2, 3, 4]]
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': null
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': null
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            postcode: '20002'
+        }
+    }), {
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+            postcode: '20002'
+        }
+    });
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': '1234',
+            postcode: '20002'
+        }
+    }), false);
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': '_%^$*—',
+            postcode: '20002'
+        }
+    }), false);
+
+    t.deepEquals(post({
+        properties: {
+            'carmen:addressnumber': [[1]],
+            'carmen:text': 'Main St',
+        }
+    }), false);
+
+    t.end();
+});


### PR DESCRIPTION
## Context

Adds a post scrip to filter out orphan addresses clusters that only contain a single address point and where at least one of the following is true:
- the street name is just numbers (e.g. `0000`)
- the street name is just US ASCII standard punctuation (e.g. `_`) -- @ingalls thoughts on additional punctuation checks we should add? I didn't initially want to filter out punctuation in other languages without knowing if all punctuation street names were in valid in other countries
- the address point doesn't have a post code property assigned