### PR TITLE
Run discard-bad-orphans post script after props post script

### DIFF
--- a/lib/post/discard-bad-orphans.js
+++ b/lib/post/discard-bad-orphans.js
@@ -3,7 +3,7 @@
  * - there's only one address in the cluster
  * - the 'carmen:text' is all numbers
  * - the 'carmen:text' is all punctuation (based on standard punctuation for US-ASCII)
- * - the feature doesn't contain a postcode property
+ * - the feature doesn't contain an 'override:postcode' property
  * @param {Object} feat     GeoJSON Feature for examination
  * @return {Object}         Output GeoJSON feature to write to output or false to drop feature
  */
@@ -16,14 +16,13 @@ function post(feat) {
         Array.isArray(feat.properties['carmen:addressnumber'][0]) &&
         feat.properties['carmen:addressnumber'][0].length === 1 &&
 
-        typeof feat.properties['carmen:text'] === 'string' &&
-
-        Array.isArray(feat.properties.address_props)
+        typeof feat.properties['carmen:text'] === 'string'
     ) {
+        if (feat.properties.address_props) throw new Error('discard-bad-orphans must be run after the props post script');
+
         const text = feat.properties['carmen:text'].trim();
 
-        if (!feat.properties.address_props.length >= 1 ||
-            !feat.properties.address_props[0]['override:postcode'] ||
+        if (!feat.properties['override:postcode'] ||
             /^\d+$/.test(text) ||
             /^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/.test(text)
         ) return false;

--- a/test/post.discard-bad-orphans.test.js
+++ b/test/post.discard-bad-orphans.test.js
@@ -61,48 +61,27 @@ test('Post: Discard Bad Orphans', (t) => {
         }
     });
 
-    t.deepEquals(post({
-        properties: {
-            'carmen:addressnumber': [[1]],
-            'carmen:text': '1234',
-        }
-    }), {
-        properties: {
-            'carmen:addressnumber': [[1]],
-            'carmen:text': '1234',
-        }
-    });
-
+    t.throws(() => {
+        post({
+            properties: {
+                'carmen:addressnumber': [[1]],
+                'carmen:text': 'Main St',
+                address_props: []
+            }
+        })
+    }, /discard-bad-orphans must be run after the props post script/);
 
     t.deepEquals(post({
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            address_props: ''
+            'override:postcode': '20002'
         }
     }), {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            address_props: ''
-        }
-    });
-
-    t.deepEquals(post({
-        properties: {
-            'carmen:addressnumber': [[1]],
-            'carmen:text': 'Main St',
-            address_props: [{
-                'override:postcode': '20002'
-            }]
-        }
-    }), {
-        properties: {
-            'carmen:addressnumber': [[1]],
-            'carmen:text': 'Main St',
-            address_props: [{
-                'override:postcode': '20002'
-            }]
+            'override:postcode': '20002'
         }
     });
 
@@ -110,9 +89,7 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': '1234',
-            address_props: [{
-                'override:postcode': '20002'
-            }]
+            'override:postcode': '20002'
         }
     }), false);
 
@@ -120,9 +97,7 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': '_%^$*—',
-            address_props: [{
-                'override:postcode': '20002'
-            }]
+            'override:postcode': '20002'
         }
     }), false);
 
@@ -130,7 +105,6 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            address_props: []
         }
     }), false);
 
@@ -138,17 +112,7 @@ test('Post: Discard Bad Orphans', (t) => {
         properties: {
             'carmen:addressnumber': [[1]],
             'carmen:text': 'Main St',
-            address_props: [{}]
-        }
-    }), false);
-
-    t.deepEquals(post({
-        properties: {
-            'carmen:addressnumber': [[1]],
-            'carmen:text': 'Main St',
-            address_props: [{
-                'override:postcode': null
-            }]
+            'override:postcode': null
         }
     }), false);
 


### PR DESCRIPTION
## Context

Follow up to https://github.com/ingalls/pt2itp/pull/447. Ensures discard-bad-orphans post script is run after the `props` post script and expects the geojson format created by that script to check for the existence of the `override:postcode` property.

## Next steps

- [ ] review by @ingalls 
- [ ] new patch release