### PR TITLE
Node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,10 @@ jobs:
             - run:
                 name: "Install NodeJS"
                 command: |
-                  curl 'https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.gz' | tar -xzv \
-                  && cp ./node-v10.15.0-linux-x64/bin/node /usr/bin/ \
-                  && ./node-v10.15.0-linux-x64/bin/npm install -g yarn \
-                  && ./node-v10.15.0-linux-x64/bin/npm install -g npm \
+                  curl 'https://nodejs.org/dist/v10.15.0/node-v10.15.3-linux-x64.tar.gz' | tar -xzv \
+                  && cp ./node-v10.15.3-linux-x64/bin/node /usr/bin/ \
+                  && ./node-v10.15.3-linux-x64/bin/npm install -g yarn \
+                  && ./node-v10.15.3-linux-x64/bin/npm install -g npm \
                   yarn install
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             - run:
                 name: "Install NodeJS"
                 command: |
-                  curl 'https://nodejs.org/dist/v10.15.0/node-v10.15.3-linux-x64.tar.gz' | tar -xzv \
+                  curl 'https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.gz' | tar -xzv \
                   && cp ./node-v10.15.3-linux-x64/bin/node /usr/bin/ \
                   && ./node-v10.15.3-linux-x64/bin/npm install -g yarn \
                   && ./node-v10.15.3-linux-x64/bin/npm install -g npm \

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     }
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
PT2ITP has been using node 10 for quite some time in its tests/CI infrastructure but we've only been posting Node 8 binaries. 

This PR will bump the version to `pt2itp@20`, dropping support for node 8. Moving forward we will post node 10 binaries.

