### PR TITLE
Format final address output

### DIFF
--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -244,7 +244,7 @@ class Compare {
     }
 
     format(feat) {
-        let street = feat.properties.number;
+        let street = feat.properties.street;
         let number = feat.properties.number;
 
         if (!number || !number.trim()) return;

--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -228,7 +228,7 @@ class Compare {
      */
     
     create(feat) {
-        feat = format(feat);
+        feat = this.format(feat);
         if (!feat) return;
 
         return {
@@ -248,7 +248,7 @@ class Compare {
         let number = feat.properties.number;
 
         if (!number || !number.trim()) return;
-        
+
         street = street.filter((streetProps) => {
             return streetProps.display.trim();
         });

--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -188,6 +188,10 @@ class Compare {
     }
 
     compare(new_address, rows) {
+        if (!Array.isArray(new_address.properties.street)) {
+            new_address.properties.street = [{ display: new_address.properties.street, priority: 0 }];
+        }
+
         // The address does not exist in the database and should be created
         if (rows.length === 0) return this.create(new_address);
 
@@ -195,10 +199,6 @@ class Compare {
         rows = rows.filter((row) => {
             return turf.distance(new_address, row.feat.geometry, { units: 'kilometers' }) < 0.5;
         });
-
-        if (!Array.isArray(new_address.properties.street)) {
-            new_address.properties.street = [{ display: new_address.properties.street, priority: 0 }];
-        }
 
         const potentials = new_address.properties.street.map((name) => {
             return tokenize.replaceToken(tokenRegex, tokenize.main(name.display, this.opts.tokens, true).tokens.join(' '));
@@ -226,7 +226,11 @@ class Compare {
      * @param {Object} feat GeoJSON Point Feature with address properties
      * @return {Object} GeoJSON Point Feature with additional hecate properties
      */
+    
     create(feat) {
+        feat = format(feat);
+        if (!feat) return;
+
         return {
             action: 'create',
             type: 'Feature',
@@ -237,6 +241,21 @@ class Compare {
             },
             geometry: feat.geometry
         };
+    }
+
+    format(feat) {
+        let street = feat.properties.number;
+        let number = feat.properties.number;
+
+        if (!number || !number.trim()) return;
+        
+        street = street.filter((streetProps) => {
+            return streetProps.display.trim();
+        });
+
+        if (!street.length) return;
+        feat.properties.street = street;
+        return feat;
     }
 
     /**

--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -226,7 +226,7 @@ class Compare {
      * @param {Object} feat GeoJSON Point Feature with address properties
      * @return {Object} GeoJSON Point Feature with additional hecate properties
      */
-    
+
     create(feat) {
         feat = this.format(feat);
         if (!feat) return;
@@ -245,7 +245,7 @@ class Compare {
 
     format(feat) {
         let street = feat.properties.street;
-        let number = feat.properties.number;
+        const number = feat.properties.number;
 
         if (!number || !number.trim()) return;
 

--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -247,10 +247,10 @@ class Compare {
         let street = feat.properties.street;
         const number = feat.properties.number;
 
-        if (!number || !number.trim()) return;
+        if (!number) return;
 
         street = street.filter((streetProps) => {
-            return streetProps.display.trim();
+            return streetProps.display;
         });
 
         if (!street.length) return;


### PR DESCRIPTION
## Context
Address points output contains:
:point_right:  `street` property is a `string`, instead of the expected `array`
```
// Example
{"action":"create","type":"Feature","properties":{"number":"1030 rear","street":"1ST AVE","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.3914055,40.5109113]}}
{"action":"create","type":"Feature","properties":{"number":"2062 rear","street":"ADAMS AVE","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.2406689,40.6846863]}}
{"action":"create","type":"Feature","properties":{"number":"415 rear","street":"W  20TH ST","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.2406042,40.6831205]}}

```
:point_right:  `street` property is empty
```
// Example
{"action":"create","type":"Feature","properties":{"number":"0","street":"","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.3459447,40.4070238]}}
{"action":"create","type":"Feature","properties":{"number":"0","street":"","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.2598699,40.5063601]}}
{"action":"create","type":"Feature","properties":{"number":"0","street":"","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.5463529,40.3972072]}}
``` 

:point_right: `number` property is empty.
```
{"action":"create","type":"Feature","properties":{"number":"","street":"","source":"openaddresses,blair"},"geometry":{"type":"Point","coordinates":[-78.3230357,40.3034502]}}
```

## Summary of changes
- Moved converting street to array section before we create the new_address
- Added a new function to verify if the feature has empty value in street or number properties.

@ingalls 