### PR TITLE
[phase 1] Support regex replacements for fancy-regex

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -56,6 +56,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "block-buffer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +223,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fancy-regex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +296,11 @@ dependencies = [
 [[package]]
 name = "itoa"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -460,8 +489,10 @@ name = "pt2itp"
 version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -770,6 +801,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
+"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
@@ -791,6 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0decc1ae13c103787f0a543307ee8dac9deceecdb463aceaff35bbb7068d86c2"
 "checksum fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
@@ -800,6 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -24,6 +24,8 @@ neon-serde = "0.1.1"
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
+fancy-regex = "0.1.0"
+memchr = "2.0.2"
 
 [dependencies.postgres]
 version = "0.15.2"

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -1,5 +1,6 @@
 mod diacritics;
 mod tokens;
+mod replace;
 
 //
 // A note on fn names:

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -13,21 +13,25 @@ impl ReplaceAll for Regex {
 
         if rep.contains("$") {
             while input.len() > 0 {
+                // captures finds the left-most first match in a string
                 match self.captures(input)? {
                     None => {
                         new.push_str(&input);
                         break;
                     },
                     Some(m) => {
+                        // capture group 0 always corresponds to the entire match
                         let pos = (m.pos(0).unwrap().0, m.pos(0).unwrap().1);
+                        // add the string up until the beginning of the match to the output
                         new.push_str(&input[..pos.0]);
+                        // add the capture group replacement to the output
                         expand_str(&m, &rep, &mut new);
+                        // set input to the original string from the end of the match and repeat
                         input = &input[pos.1..];
                     }
                 }
             }
-        }
-        else {
+        } else {
             while input.len() > 0 {
                 match self.find(input)? {
                     None => {

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -151,8 +151,7 @@ mod tests {
 
         assert_eq!(Regex::new("([a-z]+)vagen").unwrap().replace_all("123 main st", "$1v").unwrap(), "123 main st");
         assert_eq!(Regex::new("([a-z]+)vagen").unwrap().replace_all("amanuensvagen 5 stockholm sweden", "$1v").unwrap(), "amanuensv 5 stockholm sweden");
-        assert_eq!(Regex::new("([a-z]+)vagen").unwrap().replace_all("hi amanuensvagen hello gutenvagen", "$1v").unwrap(), "hi amanuensv hello gutenv");
-        // assert_eq!(Regex::new("((?!apartment|apt|bldg|building|rm|room|unit|fl|floor|ste|suite)[a-z]{2,}) # ?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)").unwrap().replace_all("123 main st floor #5 suite # 113", "$1").unwrap(), "123 main st floor suite");
+        assert_eq!(Regex::new("([a-z]+)vagen").unwrap().replace_all("amanuensvagen 5 stockholm sweden gutenvagen", "$1v").unwrap(), "amanuensv 5 stockholm sweden gutenv");
         assert_eq!(Regex::new("([^ ]+)(strasse|straße|str)").unwrap().replace_all("wilhelmstraße 3", "$1 str").unwrap(), "wilhelm str 3");
         assert_eq!(Regex::new("(foo) (bar)").unwrap().replace_all("foo bar", "$2 $1").unwrap(), "bar foo");
     }

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -1,0 +1,180 @@
+extern crate fancy_regex;
+extern crate regex;
+
+use fancy_regex::Regex;
+use fancy_regex::Captures;
+
+use std::str;
+
+use memchr::memchr;
+
+fn replace(query: &str, re: Regex, replacer: &str) -> String {
+    let mut input = &query[..];
+    let mut output = String::new();
+
+    if replacer.contains("$") {
+        while input.len() > 0 {
+            let result = re.captures(input).unwrap();
+            match result {
+                None => {
+                    output.push_str(&input);
+                    break;
+                },
+                Some(r) => {
+                    let pos = (r.pos(0).unwrap().0, r.pos(0).unwrap().1);
+                    output.push_str(&input[..pos.0]);
+                    expand_str(&r, &replacer, &mut output);
+                    input = &input[pos.1..];
+                }
+            }
+        }
+    }
+    else {
+        while input.len() > 0 {
+            match re.find(input).unwrap() {
+                None => {
+                    output.push_str(&input);
+                    break;
+                },
+                Some(m) => {
+                    output.push_str(&input[..m.0]);
+                    output.push_str(&replacer);
+                    input = &input[m.1..];
+                }
+            }
+        }
+    }
+    output
+}
+
+/// The following functions, structs, and enums are copied from the core Rust regex crate
+/// They add capture group replacement functionality currently not supported by fancy-regex
+///  License MIT
+
+
+/// A reference to a capture group in some text.
+///
+/// e.g., `$2`, `$foo`, `${foo}`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Ref<'a> {
+    Named(&'a str),
+    Number(usize),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CaptureRef<'a> {
+    cap: Ref<'a>,
+    end: usize,
+}
+
+fn expand_str(
+    caps: &Captures,
+    mut replacement: &str,
+    dst: &mut String,
+) {
+    while !replacement.is_empty() {
+        match memchr(b'$', replacement.as_bytes()) {
+            None => break,
+            Some(i) => {
+                dst.push_str(&replacement[..i]);
+                replacement = &replacement[i..];
+            }
+        }
+        if replacement.as_bytes().get(1).map_or(false, |&b| b == b'$') {
+            dst.push_str("$");
+            replacement = &replacement[2..];
+            continue;
+        }
+        debug_assert!(!replacement.is_empty());
+        let cap_ref = match find_cap_ref(replacement) {
+            Some(cap_ref) => cap_ref,
+            None => {
+                dst.push_str("$");
+                replacement = &replacement[1..];
+                continue;
+            }
+        };
+        replacement = &replacement[cap_ref.end..];
+        match cap_ref.cap {
+            Ref::Number(i) => {
+                dst.push_str(
+                    caps.at(i).map(|m| m).unwrap_or(""));
+            }
+            _ => panic!("dependency fancy-regex does not supported named capture groups")
+        }
+    }
+    dst.push_str(replacement);
+}
+
+/// Parses a possible reference to a capture group name in the given text,
+/// starting at the beginning of `replacement`.
+///
+/// If no such valid reference could be found, None is returned.
+fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(
+    replacement: &T,
+) -> Option<CaptureRef> {
+    let mut i = 0;
+    let rep: &[u8] = replacement.as_ref();
+    if rep.len() <= 1 || rep[0] != b'$' {
+        return None;
+    }
+    let mut brace = false;
+    i += 1;
+    if rep[i] == b'{' {
+        brace = true;
+        i += 1;
+    }
+    let mut cap_end = i;
+    while rep.get(cap_end).map_or(false, is_valid_cap_letter) {
+        cap_end += 1;
+    }
+    if cap_end == i {
+        return None;
+    }
+    // We just verified that the range 0..cap_end is valid ASCII, so it must
+    // therefore be valid UTF-8. If we really cared, we could avoid this UTF-8
+    // check with either unsafe or by parsing the number straight from &[u8].
+    let cap = str::from_utf8(&rep[i..cap_end])
+                  .expect("valid UTF-8 capture name");
+    // println!("cap {:#?}, cap.parse {:#?}", cap, cap.parse::<u32>());
+    if brace {
+        if !rep.get(cap_end).map_or(false, |&b| b == b'}') {
+            return None;
+        }
+        cap_end += 1;
+    }
+    Some(CaptureRef {
+        cap: match cap.parse::<u32>() {
+            Ok(i) => Ref::Number(i as usize),
+            Err(_) => Ref::Named(cap),
+        },
+        end: cap_end,
+    })
+}
+
+/// Returns true if and only if the given byte is allowed in a capture name.
+fn is_valid_cap_letter(b: &u8) -> bool {
+    match *b {
+        b'0' ... b'9' | b'a' ... b'z' | b'A' ... b'Z' | b'_' => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replace() {
+        assert_eq!(replace("foo! foo foo! foo", Regex::new("\\w+(?=!)").unwrap(), "bar"), "bar! foo bar! foo");
+        assert_eq!(replace("123 Main St apt #5", Regex::new("(?:apartment|apt|bldg|building|rm|room|unit) #?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)").unwrap(), ""), "123 Main St ");
+        assert_eq!(replace("123 Main St floor 5", Regex::new("(?:floor|fl) #?\\d{1,3}").unwrap(), ""), "123 Main St ");
+        assert_eq!(replace("123 Main St 5th floor", Regex::new("\\d{1,3}(?:st|nd|rd|th) (?:floor|fl)").unwrap(), ""), "123 Main St ");
+        assert_eq!(replace("1丁目 意思", Regex::new("[１1]丁目").unwrap(), "一丁目"), "一丁目 意思");
+
+        assert_eq!(replace("hi amanuensvagen hello", Regex::new("([a-z]+)vagen").unwrap(), "${1}v"), "hi amanuensv hello");
+        assert_eq!(replace("hi amanuensvagen hello gutenvagen", Regex::new("([a-z]+)vagen").unwrap(), "${1}v"), "hi amanuensv hello gutenv");
+        assert_eq!(replace("123 main st floor #5", Regex::new("((?!apartment|apt|bldg|building|rm|room|unit|fl|floor|ste|suite)[a-z]{2,}) # ?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)").unwrap(), "$1"), "123 main st floor");
+        assert_eq!(replace("wilhelmstraße 3", Regex::new("([^ ]+)(strasse|straße|str)").unwrap(), "$1 str"), "wilhelm str 3");
+    }
+}


### PR DESCRIPTION
## Context

Ref https://github.com/ingalls/pt2itp/issues/457. Phase 1 of the work to port pt2itp token replacements to Rust and improve token handling. Creates a `replace` function that handles simple and capture group replacements for fancy-regex `Regex` structs. Note that like fancy-regex itself (and unlike Rust's core regex crate), `replace` does not support named capture groups.

## Next steps
- [x] get tests passing
- [x] make `replace` public, ~(maybe) implement as a method~ implement as a trait on `Regex` structs
- [x] add more tests for more replacement cases (e.g. no match, multiple numbered replacers, etc)
- [x] add better error handling if the replacement contains a named capture group
- [x] see if you can remove any code ported from the core regex crate
- [x] improve how we parse certain numbered capture groups; for example, the core regex library will interpret `$1v` to be a named capture group called `1v` rather than the numbered capture group `1` followed by the character `v`

cc @ingalls @samely @boblannon 
