### PR TITLE
Orphan Geometry Order Bug

### DIFF
--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -138,7 +138,7 @@ class Orphan {
                             }
                         };
 
-                        let geom_hash = {};
+                        const geom_hash = {};
                         for (const coord of row.geom.coordinates) {
                             geom_hash[coord.pop()] = coord;
                         }

--- a/lib/map/orphan.js
+++ b/lib/map/orphan.js
@@ -62,7 +62,7 @@ class Orphan {
                     json_agg(props) as props
                 FROM (
                     SELECT
-                        address.id,
+                        address.id AS id,
                         address_orphan_cluster.names,
                         address_orphan_cluster.geom,
                         json_build_object(
@@ -127,7 +127,7 @@ class Orphan {
                             properties: {
                                 address_props: [],
                                 'carmen:text': row.name,
-                                'carmen:addressnumber': []
+                                'carmen:addressnumber': [[]]
                             },
                             geometry: {
                                 type: 'GeometryCollection',
@@ -138,21 +138,20 @@ class Orphan {
                             }
                         };
 
-                        row.geom.coordinates.forEach((coord) => {
-                            coord.pop();
-                            feat.geometry.geometries[0].coordinates.push(coord);
-                        });
+                        let geom_hash = {};
+                        for (const coord of row.geom.coordinates) {
+                            geom_hash[coord.pop()] = coord;
+                        }
 
-                        row.props.forEach((prop) => {
-                            feat.properties['carmen:addressnumber'].push(prop.number);
-
+                        for (const prop of row.props) {
+                            feat.geometry.geometries[0].coordinates.push(geom_hash[prop.id]);
+                            feat.properties['carmen:addressnumber'][0].push(prop.number);
                             feat.properties.address_props.push(prop.props);
-                        });
+                        }
 
                         if (feat.geometry.geometries[0].coordinates.length) {
-                            feat.properties['carmen:addressnumber'] = [feat.properties['carmen:addressnumber']];
-
                             if (self.opts.country) feat.properties['carmen:geocoder_stack'] = self.opts.country;
+
                             feat = self.post.feat(feat);
 
                             if (feat) self.output.write(JSON.stringify(feat) + '\n');


### PR DESCRIPTION
Orphan addresses could occasionally lose their 1:1 relation between the geometry and their corresponding address due to inconsistencies moving between the postgres geometry and the GeoJSON MultiPoint geometries.  This updates the orphan code to no longer use or trust parallel arrays, instead generating a lookup hash.