### PR TITLE
[phase 3] Make tokenized an array, remove tokenless

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=master#f25c4ecb67e9636fe4368fac42412d0ba3c8751f"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=phase-3#dbcbaac160b931e2003cff2b366c130674257e24"
 dependencies = [
  "alphanumeric-sort 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,7 +507,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)",
+ "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=phase-3)",
  "geojson 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum geo-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05350aaba2e842c89fc8e1b2e74eefded6f2abe6ce5e0f5b9037c4b71c9b3598"
-"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)" = "<none>"
+"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=phase-3)" = "<none>"
 "checksum geojson 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8125b7b9f6b0e34d7a4fae7081f5c0d212da7580077259dd1c2c8c70700b85c0"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -26,7 +26,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "phase-3" }
 
 [dependencies.postgres]
 version = "0.15.2"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -34,6 +34,7 @@ pub use self::types::Polygon;
 pub use self::types::hecate;
 pub use self::types::Context;
 pub use self::text::Tokens;
+pub use self::text::Tokenized;
 
 pub use self::types::Names;
 pub use self::types::Name;

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -62,9 +62,8 @@ pub fn distance<T>(a: &T, b: &T) -> usize
 ///
 pub fn is_numbered(name: &Name) -> Option<String> {
     let tokens: Vec<String> = name.tokenized
-        .clone()
-        .into_iter()
-        .map(|x| x.token.to_string())
+        .iter()
+        .map(|x| x.token.to_owned())
         .collect();
 
     lazy_static! {
@@ -89,9 +88,8 @@ pub fn is_numbered(name: &Name) -> Option<String> {
 ///
 pub fn is_routish(name: &Name) -> Option<String> {
     let tokens: Vec<String> = name.tokenized
-        .clone()
-        .into_iter()
-        .map(|x| String::from(x.token))
+        .iter()
+        .map(|x| x.token.to_owned())
         .collect();
 
     lazy_static! {
@@ -201,8 +199,8 @@ pub fn syn_ca_french(name: &Name, context: &Context) -> Vec<Name> {
         && !eliminator.contains(&name.tokenized[1].token)
     {
         let tokens: Vec<String> = name.tokenized[1..name.tokenized.len()]
-            .into_iter()
-            .map(|x| x.token.to_string())
+            .iter()
+            .map(|x| x.token.to_owned())
             .collect();
         let basic = tokens.join(" ").trim().to_string();
 

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -11,6 +11,7 @@ mod replace;
 
 pub use self::diacritics::diacritics;
 pub use self::tokens::Tokens;
+pub use self::tokens::Tokenized;
 
 use std::collections::HashMap;
 use regex::{Regex, RegexSet};
@@ -182,23 +183,22 @@ pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {
 /// alone. This creates less desirable synonyms for these cases
 ///
 pub fn syn_ca_french(name: &Name, context: &Context) -> Vec<Name> {
-    lazy_static! {
-        static ref STANDALONE: Regex = Regex::new(r"^(r|ch|av|bd)\s").unwrap();
-
-        static ref ELIMINATOR: Regex = Regex::new(r"^(r|ch|av|bd)\s(du|des|de)\s").unwrap();
-    }
-
     let mut syns = Vec::new();
+    let standalone = vec![String::from("r"), String::from("ch"), String::from("av"), String::from("bd")];
+    let eliminator = vec![String::from("du"), String::from("des"), String::from("de")];
 
     if
-        STANDALONE.is_match(&*name.tokenized)
-        && !ELIMINATOR.is_match(&*name.tokenized)
+        standalone.contains(&name.tokenized[0].token)
+        && !eliminator.contains(&name.tokenized[1].token)
     {
-        let basic = STANDALONE.replace(&*name.tokenized, "").to_string();
+        let tokens: Vec<String> = name.tokenized[1..name.tokenized.len()]
+            .into_iter()
+            .map(|x| x.token.to_string())
+            .collect();
+        let basic = tokens.join(" ").trim().to_string();
 
         syns.push(Name::new(basic, -1, &context));
     }
-
 
     syns
 }

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -12,6 +12,7 @@ mod replace;
 pub use self::diacritics::diacritics;
 pub use self::tokens::Tokens;
 pub use self::tokens::Tokenized;
+pub use self::tokens::ParsedToken;
 
 use std::collections::HashMap;
 use regex::{Regex, RegexSet};
@@ -60,14 +61,18 @@ pub fn distance<T>(a: &T, b: &T) -> usize
 /// Is the street a numbered street: ie 1st, 2nd, 3rd etc
 ///
 pub fn is_numbered(name: &Name) -> Option<String> {
-    let tokens = name.tokenized.split(' ');
+    let tokens: Vec<String> = name.tokenized
+        .clone()
+        .into_iter()
+        .map(|x| x.token.to_string())
+        .collect();
 
     lazy_static! {
         static ref NUMBERED: Regex = Regex::new(r"^(?P<num>([0-9]+)?(1st|2nd|3rd|[0-9]th))$").unwrap();
     }
 
     for token in tokens {
-        match NUMBERED.captures(token) {
+        match NUMBERED.captures(&token) {
             Some(capture) => {
                 return Some(capture["num"].to_string());
             }
@@ -83,14 +88,18 @@ pub fn is_numbered(name: &Name) -> Option<String> {
 /// ie: US Route 4
 ///
 pub fn is_routish(name: &Name) -> Option<String> {
-    let tokens = name.tokenized.split(' ');
+    let tokens: Vec<String> = name.tokenized
+        .clone()
+        .into_iter()
+        .map(|x| String::from(x.token))
+        .collect();
 
     lazy_static! {
         static ref ROUTISH: Regex = Regex::new(r"^(?P<num>\d+)$").unwrap();
     }
 
     for token in tokens {
-        match ROUTISH.captures(token) {
+        match ROUTISH.captures(&token) {
             Some(capture) => {
                 return Some(capture["num"].to_string());
             }

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -11,13 +11,13 @@ pub struct Tokens {
 impl Tokens {
     pub fn new(tokens: HashMap<String, ParsedToken>) -> Self {
         Tokens {
-            tokens
+            tokens: tokens
         }
     }
 
     pub fn generate(languages: Vec<String>) -> Self {
         let import: HashMap<String, Vec<Token>> = geocoder_abbreviations::config(languages).unwrap();
-        let mut map: HashMap<String, String> = HashMap::new();
+        let mut map: HashMap<String, ParsedToken> = HashMap::new();
 
         for language in import.keys() {
             for group in import.get(language).unwrap() {
@@ -94,7 +94,7 @@ impl Tokens {
 
 /// Simplified struct from geocoder_abbreviations::Token
 /// @TODO replace with geocoder_abbreviations::Token when additional traits are derived
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ParsedToken {
     canonical: String,
     token_type: Option<TokenType>

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -109,7 +109,7 @@ impl ParsedToken {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Tokenized {
     pub token: String,
     pub token_type: Option<TokenType>
@@ -131,7 +131,7 @@ mod tests {
     fn concat(tokenized: Vec<Tokenized>) -> String {
         let tokens: Vec<String> = tokenized
             .into_iter()
-            .map(|x| x.token.to_string())
+            .map(|x| String::from(x.token))
             .collect();
         let token_string = tokens.join(" ").trim().to_string();
         token_string

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -26,7 +26,7 @@ impl Tokens {
                     for tk in &group.tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
-                            ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.clone())
+                            ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
                         );
                     }
                 }
@@ -46,10 +46,10 @@ impl Tokens {
         for token in tokens {
             match self.tokens.get(&token) {
                 None => {
-                    tokenized.push(Tokenized::new(token.clone(), None));
+                    tokenized.push(Tokenized::new(token.to_owned(), None));
                 },
                 Some(t) => {
-                    tokenized.push(Tokenized::new(t.canonical.clone(), t.token_type.clone()));
+                    tokenized.push(Tokenized::new(t.canonical.to_owned(), t.token_type.to_owned()));
                 }
             };
         }
@@ -109,7 +109,7 @@ impl ParsedToken {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Tokenized {
     pub token: String,
     pub token_type: Option<TokenType>
@@ -128,12 +128,12 @@ impl Tokenized {
 mod tests {
     use super::*;
 
-    fn concat(tokenized: Vec<Tokenized>) -> String {
+    fn tokenized_string(tokenized: Vec<Tokenized>) -> String {
         let tokens: Vec<String> = tokenized
             .into_iter()
             .map(|x| String::from(x.token))
             .collect();
-        let token_string = tokens.join(" ").trim().to_string();
+        let token_string = String::from(tokens.join(" ").trim());
         token_string
     }
 
@@ -142,51 +142,51 @@ mod tests {
         let tokens = Tokens::new(HashMap::new());
 
         // diacritics are removed from latin text
-        assert_eq!(concat(tokens.process(&String::from("Hérê àrë søme wöřdš, including diacritics and puncatuation!"))), String::from("here are some words including diacritics and puncatuation"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("Hérê àrë søme wöřdš, including diacritics and puncatuation!"))), String::from("here are some words including diacritics and puncatuation"));
 
         // nothing happens to latin text
-        assert_eq!(concat(tokens.process(&String::from("Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)"))), String::from("cranberries are low creeping shrubs or vines up to 2 metres 7 ft"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)"))), String::from("cranberries are low creeping shrubs or vines up to 2 metres 7 ft"));
 
         // nothing happens to Japanese text
-        assert_eq!(concat(tokens.process(&String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"))), String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"))), String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"));
 
         // greek diacritics are removed and other characters stay the same
-        assert_eq!(concat(tokens.process(&String::from("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"))), String::from("άάέέήήίίόόύύ ααεεηηιιοουυ"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"))), String::from("άάέέήήίίόόύύ ααεεηηιιοουυ"));
 
         // cyrillic diacritics are removed and other characters stay the same
-        assert_eq!(concat(tokens.process(&String::from("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"))), String::from("ўўёёѐѐґґйй ууееееггии"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"))), String::from("ўўёёѐѐґґйй ууееееггии"));
     }
 
     #[test]
     fn test_tokenize() {
         let tokens = Tokens::new(HashMap::new());
 
-        assert_eq!(concat(tokens.process(&String::from(""))), String::from(""));
+        assert_eq!(tokenized_string(tokens.process(&String::from(""))), String::from(""));
 
-        assert_eq!(concat(tokens.process(&String::from("foo"))), String::from("foo"));
-        assert_eq!(concat(tokens.process(&String::from("foo bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo-bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo+bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo_bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo:bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo;bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo|bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo}bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo{bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo[bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo]bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo(bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo)bar"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo b.a.r"))), String::from("foo bar"));
-        assert_eq!(concat(tokens.process(&String::from("foo's bar"))), String::from("foos bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo"))), String::from("foo"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo-bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo+bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo_bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo:bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo;bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo|bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo}bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo{bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo[bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo]bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo(bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo)bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo b.a.r"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo's bar"))), String::from("foos bar"));
 
-        assert_eq!(concat(tokens.process(&String::from("San José"))), String::from("san jose"));
-        assert_eq!(concat(tokens.process(&String::from("A Coruña"))), String::from("a coruna"));
-        assert_eq!(concat(tokens.process(&String::from("Chamonix-Mont-Blanc"))), String::from("chamonix mont blanc"));
-        assert_eq!(concat(tokens.process(&String::from("Rue d'Argout"))), String::from("rue dargout"));
-        assert_eq!(concat(tokens.process(&String::from("Hale’iwa Road"))), String::from("haleiwa road"));
-        assert_eq!(concat(tokens.process(&String::from("москва"))), String::from("москва"));
-        assert_eq!(concat(tokens.process(&String::from("京都市"))), String::from("京都市"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("San José"))), String::from("san jose"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("A Coruña"))), String::from("a coruna"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("Chamonix-Mont-Blanc"))), String::from("chamonix mont blanc"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("Rue d'Argout"))), String::from("rue dargout"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("Hale’iwa Road"))), String::from("haleiwa road"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("москва"))), String::from("москва"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("京都市"))), String::from("京都市"));
     }
 
     #[test]

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -1,5 +1,5 @@
 use crate::{Context, text};
-use crate::{Tokenized};
+use crate::Tokenized;
 
 ///
 /// InputName is only used internally to serialize a names array to the
@@ -148,6 +148,27 @@ impl Name {
             tokenized: tokenized,
             freq: 1
         }
+    }
+
+    pub fn tokenized_string(&self) -> String {
+        let tokens: Vec<String> = self.tokenized
+            .iter()
+            .map(|x| x.token.to_owned())
+            .collect();
+        let tokenized = String::from(tokens.join(" ").trim());
+
+        tokenized
+    }
+
+    pub fn tokenless_string(&self) -> String {
+        let tokens: Vec<String> = self.tokenized
+            .iter()
+            .filter(|x| x.token_type.is_none())
+            .map(|x| x.token.to_owned())
+            .collect();
+        let tokenless = String::from(tokens.join(" ").trim());
+
+        tokenless
     }
 }
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -1,4 +1,5 @@
 use crate::{Context, text};
+use crate::{Tokenized};
 
 ///
 /// InputName is only used internally to serialize a names array to the
@@ -115,11 +116,8 @@ pub struct Name {
     /// Geometry Type of a given name (network/address)
     pub source: String,
 
-    /// Abbreviated form of the name
-    pub tokenized: String,
-
-    /// All abbreviations removed form of the name
-    pub tokenless: String,
+    /// full token structure tokenless is derived from
+    pub tokenized: Vec<Tokenized>,
 
     /// Frequency of the given name
     pub freq: i64
@@ -136,7 +134,7 @@ impl Name {
     pub fn new(display: impl ToString, priority: i8, context: &Context) -> Self {
         let mut display = display.to_string();
 
-        let tokens = context.tokens.process(&display);
+        let tokenized = context.tokens.process(&display);
 
         display = display
             .replace(r#"""#, "")
@@ -147,8 +145,7 @@ impl Name {
             display: display,
             priority: priority,
             source: String::from(""),
-            tokenized: tokens.0,
-            tokenless: tokens.1,
+            tokenized: tokenized,
             freq: 1
         }
     }
@@ -169,8 +166,10 @@ mod tests {
             display: String::from("Main St NW"),
             priority: 0,
             source: String::from(""),
-            tokenized: String::from("main st nw"),
-            tokenless: String::from("main st nw"),
+            tokenized: vec![
+                Tokenized::new(String::from("main"), None),
+                Tokenized::new(String::from("st"), None),
+                Tokenized::new(String::from("nw"), None)],
             freq: 1
         });
     }

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -169,6 +169,6 @@ mod tests {
 
         let net = Network::new(feat, &context).unwrap();
 
-        assert_eq!(net.to_tsv(), "[{\"display\":\"Poremba Court Southwest\",\"priority\":0,\"source\":\"network\",\"tokenized\":\"poremba court southwest\",\"tokenless\":\"poremba court southwest\",\"freq\":1}]\t\t{\"id\":6052094,\"street\":[{\"display\":\"Poremba Court Southwest\",\"priority\":0}]}\t0105000020E610000001000000010200000003000000FCA5457D924053C09128B4ACFB6D4340F52F49658A4053C0CBA145B6F36D434009826CFE844053C0F7D676C9EE6D4340\n");
+        assert_eq!(net.to_tsv(), "[{\"display\":\"Poremba Court Southwest\",\"priority\":0,\"source\":\"network\",\"tokenized\":[{\"token\":\"poremba\",\"token_type\":null},{\"token\":\"court\",\"token_type\":null},{\"token\":\"southwest\",\"token_type\":null}],\"freq\":1}]\t\t{\"id\":6052094,\"street\":[{\"display\":\"Poremba Court Southwest\",\"priority\":0}]}\t0105000020E610000001000000010200000003000000FCA5457D924053C09128B4ACFB6D4340F52F49658A4053C0CBA145B6F36D434009826CFE844053C0F7D676C9EE6D4340\n");
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -45,20 +45,8 @@ impl LinkResult {
 ///
 pub fn linker(primary: Link, mut potentials: Vec<Link>) -> Option<LinkResult> {
     for name in &primary.names.names {
-        let atoks: Vec<String> = name.tokenized
-            .clone()
-            .into_iter()
-            .map(|x| String::from(x.token))
-            .collect();
-        let tokenized = String::from(atoks.join(" ").trim());
-
-        let tokenless: Vec<String> = name.tokenized
-            .clone()
-            .into_iter()
-            .filter(|x| x.token_type.is_none())
-            .map(|x| String::from(x.token))
-            .collect();
-        let tokenless = String::from(tokenless.join(" ").trim());
+        let tokenized = name.tokenized_string();
+        let tokenless = name.tokenless_string();
 
         for potential in potentials.iter_mut() {
             for potential_name in &potential.names.names {
@@ -68,20 +56,8 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>) -> Option<LinkResult> {
                     return Some(LinkResult::new(*potential.id, 100.0));
                 }
 
-                let mut ntoks: Vec<String> = potential_name.tokenized
-                    .clone()
-                    .into_iter()
-                    .map(|x| String::from(x.token))
-                    .collect();
-                let potential_tokenized = String::from(ntoks.join(" ").trim());
-
-                let potential_tokenless: Vec<String> = potential_name.tokenized
-                    .clone()
-                    .into_iter()
-                    .filter(|x| x.token_type.is_none())
-                    .map(|x| String::from(x.token))
-                    .collect();
-                let potential_tokenless = String::from(potential_tokenless.join(" ").trim());
+                let potential_tokenized = potential_name.tokenized_string();
+                let potential_tokenless = potential_name.tokenless_string();
 
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens
@@ -109,9 +85,21 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>) -> Option<LinkResult> {
                 } else if (tokenless.len() > 0 && potential_tokenless.len() == 0) || (tokenless.len() == 0 && potential_tokenless.len() > 0) {
                     lev_score = Some(distance(&tokenized, &potential_tokenized) as f64);
                 } else {
+
+                    let atoks: Vec<String> = name.tokenized
+                        .iter()
+                        .map(|x| x.token.to_owned())
+                        .collect();
+
+                    let mut ntoks: Vec<String> = potential_name.tokenized
+                        .iter()
+                        .map(|x| x.token.to_owned())
+                        .collect();
+
                     let ntoks_len = ntoks.len() as f64;
 
                     let mut a_match = 0;
+
 
                     for atok in &atoks {
                         // If there are dup tokens ensure they match a unique token ie Saint Street => st st != main st


### PR DESCRIPTION
## Context

Ref https://github.com/ingalls/pt2itp/issues/457. Removes support for the `tokenless` property on features. Rather than a string, the output `tokenized` property is now an array of objects like `"tokenized": [ { "token": "main", "type": "null"}, { "token": "st", "type": "way" }]`. This will allow us to generate tokenless on the fly by dropping all tokens which have an unknown or non-street type. This work is on top of @ingalls 's changes to conflate in https://github.com/ingalls/pt2itp/pull/466.

## Summary of changes
- [ ] remove support for `tokenless` property
- [ ] make `tokenized` property an array of objects including the token type rather than a string

## Next steps
- [ ] get tests passing/incorporate any additional changes from `conflate`

cc @samely 