### PR TITLE
make number matching insensitive

### DIFF
--- a/lib/conflate/compare.js
+++ b/lib/conflate/compare.js
@@ -93,7 +93,7 @@ class Compare {
                         FROM
                             address p
                         WHERE
-                            p.number = '${new_address.properties.number}'
+                            lower(p.number) = '${new_address.properties.number.toLowerCase()}'
                             AND ST_DWithin(ST_SetSRID(ST_GeomFromGeoJSON('${JSON.stringify(new_address.geometry)}'), 4326), p.geom, 0.02);
                     `, (err, res) => {
                         if (err) return done(err);


### PR DESCRIPTION
`pt2itp` compare is case sensitive for numbers of type: `N453`

So if the number is `n453`, we will have duplicates while conflating.

@ingalls 