### PR TITLE
[phase 3] Use new tokenized format in map mode

### DIFF
--- a/lib/label/titlecase.js
+++ b/lib/label/titlecase.js
@@ -11,21 +11,22 @@ module.exports = () => {
 
     return (texts) => {
         texts = texts.map((text) => {
+            text.internal_tokenized_string = text.tokenized.map((x) => x.token).join(' ');
             if (text.priority === 0 || !text.priority) {
                 // Less Desirable street names
                 const subs = ['ext', 'extension', 'connector', 'br', 'branch', 'unit', 'apt', 'suite', 'lot'];
 
-                const tokens = text.tokenized.split(' ');
+                const tokens = text.tokenized.map((x) => x.token);
                 for (const token of tokens) {
                     if (subs.indexOf(token) >= 0) {
                         text.priority = -1;
                         break;
                     }
                 }
-
                 // Freq Values on identical tokenless values must match
                 for (const tmatch of texts) {
-                    if (text.tokenized === tmatch.tokenized && text.freq < tmatch.freq) {
+                    const tmatch_tokenized = tmatch.tokenized.map((x) => x.token).join(' ');
+                    if (text.internal_tokenized_string === tmatch_tokenized && text.freq < tmatch.freq) {
                         text.freq = tmatch.freq;
                     }
                 }
@@ -58,11 +59,11 @@ module.exports = () => {
             return name;
         });
 
-        texts = _.orderBy(texts, ['priority', 'tokenized', 'display_length'], ['desc', 'asc', 'desc']);
-        texts = _.sortedUniqBy(texts, 'tokenized');
+        texts = _.orderBy(texts, ['priority', 'internal_tokenized_string', 'display_length'], ['desc', 'asc', 'desc']);
+        texts = _.sortedUniqBy(texts, 'internal_tokenized_string');
         texts = _.orderBy(texts, ['priority', 'freq', 'display_length'], ['desc', 'desc', 'desc']);
-
         return texts.map((name) => {
+            delete name.internal_tokenized_string;
             name.display = titleCase(name.display.trim(), titleCaseConfig);
             return name;
         }).reduce((acc, name) => {

--- a/lib/map/linker.js
+++ b/lib/map/linker.js
@@ -15,7 +15,12 @@ function linker(addrs, nets, returnAll) {
 
     // Ensure each matches are always returned before potential short-circuits
     for (const addr of addrs) {
-        const eqNets = nets.filter((n) => { return n.name.tokenized === addr.tokenized; });
+        const addr_tokenized = addr.tokenized.map((x) => x.token).join(' ');
+
+        const eqNets = nets.filter((n) => {
+            const net_tokenized = n.name.tokenized.map((x) => x.token).join(' ');
+            return net_tokenized === addr_tokenized;
+        });
         if (eqNets.length) return eqNets.map((n) => {
             n.score = 100.0;
             return n;
@@ -27,13 +32,20 @@ function linker(addrs, nets, returnAll) {
     }
 
     for (const addr of addrs) {
+        // create tokenized and tokenless strings for addresses
+        const addr_tokenized = addr.tokenized.map((x) => x.token).join(' ');
+        const addr_tokenless = addr.tokenized.filter((x) => x.token_type === null).map((x) => x.token).join(' ');
+
         for (let net_it = 0; net_it < nets.length; net_it++) {
             const net = nets[net_it];
+            // create tokenized and tokenless strings for networks
+            const net_tokenized = net.name.tokenized.map((x) => x.token).join(' ');
+            const net_tokenless = net.name.tokenized.filter((x) => x.token_type === null).map((x) => x.token).join(' ');
 
             // don't bother considering if the tokenless forms don't share a starting letter
             // this might require adjustment for countries with addresses that have leading tokens which aren't properly stripped
             // from the token list
-            if (net.name.tokenless && addr.tokenless && (net.name.tokenless[0] !== addr.tokenless[0])) continue;
+            if (net_tokenless && addr_tokenless && (net_tokenless[0] !== addr_tokenless[0])) continue;
 
             // Dont bother considering if both addr and network are a numbered street that don't match (1st != 11th)
             if (addr.isNumbered && addr.isNumbered !== isNumbered(net.name.tokenized)) continue;
@@ -41,16 +53,15 @@ function linker(addrs, nets, returnAll) {
 
             // use a weighted average w/ the tokenless dist score if possible
             let levScore;
-
-            if (addr.tokenless && net.name.tokenless) {
-                levScore = (0.25 * dist(addr.tokenized, net.name.tokenized)) + (0.75 * dist(addr.tokenless, net.name.tokenless));
-            } else if ((addr.tokenless && !net.name.tokenless) || (!addr.tokenless && net.name.tokenless)) {
-                levScore = dist(addr.tokenized, net.name.tokenized);
+            if (addr_tokenless && net_tokenless) {
+                levScore = (0.25 * dist(addr_tokenized, net_tokenized)) + (0.75 * dist(addr_tokenless, net_tokenless));
+            } else if ((addr_tokenless && !net_tokenless) || (!addr_tokenless && net_tokenless)) {
+                levScore = dist(addr_tokenized, net_tokenized);
             } else {
-                const ntoks = net.name.tokenized.split(' ');
+                const ntoks = net.name.tokenized.map((x) => x.token);
                 const numntoks = ntoks.length;
                 let aMatch = 0;
-                for (const atok of addr.tokenized.split(' ')) {
+                for (const atok of addr.tokenized.map((x) => x.token)) {
                     if (ntoks.indexOf(atok) > -1) {
                         ntoks.splice(ntoks.indexOf(atok), 1); // If there are dup tokens ensure they match a unique token ie Saint Street => st st != main st
                         aMatch++;
@@ -63,11 +74,11 @@ function linker(addrs, nets, returnAll) {
                 // this can be due to an edge case like 'Avenue Street' in which all words are tokens.
                 // in this case, short-circuit if one string is fully contained within another.
 
-                if (!levScore) levScore = dist(addr.tokenized, net.name.tokenized);
+                if (!levScore) levScore = dist(addr_tokenized, net_tokenized);
             }
 
             // Calculate % Match
-            const score = 100 - (((2 * levScore) / (net.name.tokenized.length + addr.tokenized.length)) * 100);
+            const score = 100 - (((2 * levScore) / (net_tokenized.length + addr_tokenized.length)) * 100);
 
             nets[net_it].score = score;
 
@@ -87,11 +98,11 @@ function linker(addrs, nets, returnAll) {
 
 /**
  * Is the street a numered type street ie: 1st 2nd 3rd etc
- * @param {string} text Text to test against
+ * @param {Array} tokenized Array of tokenized text to test against
  * @return {boolean|string}
  */
-function isNumbered(text) {
-    const toks = text.split(' ');
+function isNumbered(tokenized) {
+    const toks = tokenized.map((x) => x.token);
 
     const tests = [
         /^(([0-9]+)?1st)$/,
@@ -112,11 +123,11 @@ function isNumbered(text) {
 
 /**
  * Is the street route type number ie US Route 4
- * @param {string} text Text to test against
+ * @param {Array} tokenized Array of tokenized text to test against
  * @return {boolean|string}
  */
-function isRoutish(text) {
-    const toks = text.split(' ');
+function isRoutish(tokenized) {
+    const toks = tokenized.map((x) => x.token);
 
     for (const tok of toks) {
         const m = tok.match(/^\d+$/);

--- a/lib/util/tokenize.js
+++ b/lib/util/tokenize.js
@@ -128,8 +128,8 @@ function createGlobalReplacer(tokens) {
  */
 function getTokens(languages) {
     let parsed = [];
-    for (const token of languages) {
-        parsed = parsed.concat(tokens(token, true)); // pull singletons in, too -- ie tokens that are common but have no abbreviation
+    for (const language of languages) {
+        parsed = parsed.concat(tokens(language, true)); // pull singletons in, too -- ie tokens that are common but have no abbreviation
     }
 
     return parsed;

--- a/test/linker.test.js
+++ b/test/linker.test.js
@@ -4,248 +4,248 @@ const linker = require('../lib/map/linker');
 const test = require('tape');
 
 test('linker#isNumbered', (t) => {
-    t.equals(linker.isNumbered('main st'), false, 'main st => false');
-    t.equals(linker.isNumbered('1st st'), '1st', '1st st => 1st');
-    t.equals(linker.isNumbered('2nd st'), '2nd', '2nd st => 2nd');
-    t.equals(linker.isNumbered('west 2nd st'), '2nd', 'west 2nd st => 2nd');
-    t.equals(linker.isNumbered('3rd st'), '3rd', '3rd st = 3rd');
-    t.equals(linker.isNumbered('4th av'), '4th', '4th av => 4th');
-    t.equals(linker.isNumbered('21st av'), '21st', '21st av => 21st');
-    t.equals(linker.isNumbered('32nd av'), '32nd', '32nd av => 32nd');
-    t.equals(linker.isNumbered('45th av'), '45th', '45th av => 45th');
-    t.equals(linker.isNumbered('351235th av'), '351235th', '351235th av => 351235th');
+    t.equals(linker.isNumbered([{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]), false, 'main st => false');
+    t.equals(linker.isNumbered([{ token: '1st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }]), '1st', '1st st => 1st');
+    t.equals(linker.isNumbered([{ token: '2nd', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }]), '2nd', '2nd st => 2nd');
+    t.equals(linker.isNumbered([{ token: 'w', token_type: 'Cardinal' }, { token: '2nd', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }]), '2nd', 'west 2nd st => 2nd');
+    t.equals(linker.isNumbered([{ token: '3rd', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }]), '3rd', '3rd st = 3rd');
+    t.equals(linker.isNumbered([{ token: '4th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), '4th', '4th av => 4th');
+    t.equals(linker.isNumbered([{ token: '21st', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), '21st', '21st av => 21st');
+    t.equals(linker.isNumbered([{ token: '32nd', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), '32nd', '32nd av => 32nd');
+    t.equals(linker.isNumbered([{ token: '45th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), '45th', '45th av => 45th');
+    t.equals(linker.isNumbered([{ token: '351235th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), '351235th', '351235th av => 351235th');
     t.end();
 });
 
 test('linker#isRoutish', (t) => {
-    t.equals(linker.isRoutish('main st'), false, 'main st => false');
-    t.equals(linker.isRoutish('1st st'), false, '1st st => false');
-    t.equals(linker.isRoutish('351235th av'), false, '351235th av => false');
-    t.equals(linker.isRoutish('NC 124'), '124', 'NC 124 => 124');
-    t.equals(linker.isRoutish('US Route 50 East'), '50', 'US Route 50 East => 50');
-    t.equals(linker.isRoutish('321'), '321', '321 => 321');
-    t.equals(linker.isRoutish('124 NC'), '124', '124 NC => 124');
+    t.equals(linker.isRoutish([{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]), false, 'main st => false');
+    t.equals(linker.isRoutish([{ token: '1st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }]), false, '1st st => false');
+    t.equals(linker.isRoutish([{ token: '351235th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }]), false, '351235th av => false');
+    t.equals(linker.isRoutish([{ token: 'nc', token_type: null }, { token: '124', token_type: null }]), '124', 'NC 124 => 124');
+    t.equals(linker.isRoutish([{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '50', token_type: null }, { token: 'e', token_type: 'Cardinal' }]), '50', 'US Route 50 East => 50');
+    t.equals(linker.isRoutish([{ token: '321', token_type: null }]), '321', '321 => 321');
+    t.equals(linker.isRoutish([{ token: '124', token_type: null }, { token: 'nc', token_type: null }]), '124', '124 NC => 124');
     t.end();
 });
 
 test('Passing Linker Matches', (t) => {
     t.deepEquals(
-        linker([{ display: 'Main Street', tokenized: 'main st' }], [
-            { id: 1, name: { display: 'Main Street', tokenized: 'main st' } }
+        linker([{ display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] } }
         ]),
-        [{ id: 1, name: { display: 'Main Street', tokenized: 'main st' }, score: 100 }],
+        [{ id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }, score: 100 }],
         'basic match');
 
     t.deepEquals(
-        linker([{ display: 'Main Street', tokenized: 'main st' }], [
-            { id: 1, name: { display: 'Maim Street', tokenized: 'maim st' } }
+        linker([{ display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Maim Street', tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }] } }
         ]),
-        [{ id: 1, name: { display: 'Maim Street', tokenized: 'maim st' }, score: 85.71428571428572 }],
+        [{ id: 1, name: { display: 'Maim Street', tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }] }, score: 85.71428571428572 }],
         'close match');
 
     t.deepEquals(
-        linker([{ display: '1st Street West', tokenized: '1st st west' }], [
-            { id: 1, name: { display: '2nd Street West', tokenized: '2nd st west' } }
+        linker([{ display: '1st Street West', tokenized: [{ token: '1st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: '2nd Street West', tokenized: [{ token: '2nd', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
         false,
         'no match numeric simple (2nd)');
 
     t.deepEquals(
-        linker([{ display: '1st Street West', tokenized: '1st st west' }], [
-            { id: 1, name: { display: '3rd Street West', tokenized: '3rd st west' } }
+        linker([{ display: '1st Street West', tokenized: [{ token: '1st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: '3rd Street West', tokenized: [{ token: '3rd', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
         false,
         'no match numeric simple (3rd)');
 
     t.deepEquals(
-        linker([{ display: '1st Street West', tokenized: '1st st west' }], [
-            { id: 1, name: { display: '4th Street West', tokenized: '4th st west' } }
+        linker([{ display: '1st Street West', tokenized: [{ token: '1st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: '4th Street West', tokenized: [{ token: '4th', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
         false,
         'no match numeric simple (4th)');
 
     t.deepEquals(
-        linker([{ display: '11th Street West', tokenized: '11th st west' }], [
-            { id: 1, name: { display: '21st Street West', tokenized: '21st st west' } }
+        linker([{ display: '11th Street West', tokenized: [{ token: '11th', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: '21st Street West', tokenized: [{ token: '21st', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
         false,
         'no match numeric simple (21st)');
 
     t.deepEquals(
-        linker([{ display: 'US Route 50 East', tokenized: 'us route 50 east' }], [
-            { id: 1, name: { display: 'US Route 50 West', tokenized: 'us route 50 west' } }
+        linker([{ display: 'US Route 50 East', tokenized: [{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '50', token_type: null }, { token: 'e', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: 'US Route 50 West', tokenized: [{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '50', token_type: null }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
-        [{ id: 1, name: { display: 'US Route 50 West', tokenized: 'us route 50 west' }, score: 95.3125 }],
+        [{ id: 1, name: { display: 'US Route 50 West', tokenized: [{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '50', token_type: null }, { token: 'w', token_type: 'Cardinal' }] }, score: 97.5 }],
         'Numbers match - cardinals don\'t');
 
     t.deepEquals(
-        linker([{ display: 'US Route 60 East', tokenized: 'us route 50 east' }], [
-            { id: 1, name: { display: 'US Route 51 West', tokenized: 'us route 51 west' } }
+        linker([{ display: 'US Route 60 East', tokenized: [{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '60', token_type: null }, { token: 'e', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: 'US Route 51 West', tokenized: [{ token: 'us', token_type: null }, { token: 'rt', token_type: 'Way' }, { token: '51', token_type: null }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
         false,
         'Number mismatch fail');
 
     t.deepEquals(
-        linker([{ display: '11th Street West', tokenized: '11th st west' }], [
-            { id: 1, name: { display: '11th Avenue West', tokenized: '11th av west' } }
+        linker([{ display: '11th Street West', tokenized: [{ token: '11th', token_type: 'Ordinal' }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { display: '11th Avenue West', tokenized: [{ token: '11th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] } }
         ]),
-        [{ id: 1, name: { display: '11th Avenue West', tokenized: '11th av west' }, score: 94.44444444444444 }],
+        [{ id: 1, name: { display: '11th Avenue West', tokenized: [{ token: '11th', token_type: 'Ordinal' }, { token: 'av', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }, score: 92.5925925925926 }],
         'match numeric simple (type mismatch)');
 
     t.deepEquals(
-        linker([{ display: 'Main Street', tokenized: 'main st' }], [
-            { id: 1, name: { display: 'Main Street', tokenized: 'main st' } },
-            { id: 2, name: { display: 'Main Avenue', tokenized: 'main av' } },
-            { id: 3, name: { display: 'Main Road', tokenized: 'main rd' } },
-            { id: 4, name: { display: 'Main Drive', tokenized: 'main dr' } }
+        linker([{ display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] } },
+            { id: 2, name: { display: 'Main Avenue', tokenized: [{ token: 'main', token_type: null }, { token: 'av', token_type: 'Way' }] } },
+            { id: 3, name: { display: 'Main Road', tokenized: [{ token: 'main', token_type: null }, { token: 'rd', token_type: 'Way' }] } },
+            { id: 4, name: { display: 'Main Drive', tokenized: [{ token: 'main', token_type: null }, { token: 'dr', token_type: 'Way' }] } }
         ]),
-        [{ id: 1, name: { display: 'Main Street', tokenized: 'main st' }, score: 100 }],
+        [{ id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }, score: 100 }],
         'diff suff');
 
     t.deepEquals(
-        linker([{ display: 'Main Street', tokenized: 'main st' }], [
-            { id: 1, name: { display: 'Main Street', tokenized: 'main st' } },
-            { id: 2, name: { display: 'Asdg Street', tokenized: 'asdg st' } },
-            { id: 3, name: { display: 'Asdg Street', tokenized: 'asdg st' } },
-            { id: 4, name: { display: 'Maim Street', tokenized: 'maim st' } }
+        linker([{ display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] } },
+            { id: 2, name: { display: 'Asdg Street', tokenized: [{ token: 'asdg', token_type: null }, { token: 'st', token_type: 'Way' }] } },
+            { id: 3, name: { display: 'Asdg Street', tokenized: [{ token: 'asdg', token_type: null }, { token: 'st', token_type: 'Way' }] } },
+            { id: 4, name: { display: 'Maim Street', tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }] } }
         ]),
-        [{ id: 1, name: { display: 'Main Street', tokenized: 'main st' }, score: 100 }],
+        [{ id: 1, name: { display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }] }, score: 100 }],
         'diff name');
 
     t.deepEquals(
-        linker([{ display: 'Ola Avenue', tokenized: 'ola ave', tokenless: 'ola' }], [
-            { id: 1, name: { display: 'Ola', tokenized: 'ola', tokenless: 'ola' } },
-            { id: 2, name: { display: 'Ola Avg' , tokenized: 'ola avg', tokenless: 'ola avg' } }
+        linker([{ display: 'Ola Avenue', tokenized: [{ token: 'ola', token_type: null }, { token: 'av', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Ola', tokenized: [{ token: 'ola', token_type: null }] } },
+            { id: 2, name: { display: 'Ola Avg' , tokenized: [{ token: 'ola', token_type: null }, { token: 'avg', token_type: null }] } }
         ]),
-        [{ id: 1, name: { display: 'Ola', tokenized: 'ola', tokenless: 'ola' }, score: 80 }],
+        [{ id: 1, name: { display: 'Ola', tokenized: [{ token: 'ola', token_type: null }] }, score: 83.33333333333334 }],
         'short names, tokens deweighted');
 
     t.deepEquals(
-        linker([{ tokenized: 'ave st', tokenless: '', display: 'Avenue Street' }], [
-            { id: 1, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' } },
-            { id: 2, name: { tokenized: 'avenida', tokenless: 'avenida' } }
+        linker([{ display: 'Avenue Street', tokenized: [{ token: 'av', token_type: 'Way' }, { token: 'st', token_type: 'Way' }] }], [
+            { id: 1, name: { display: 'Avenue', tokenized: [{ token: 'av', token_type: 'Way' }] } },
+            { id: 2, name: { display: 'Avenida', tokenized: [{ token: 'avenida', token_type: null }] } }
         ]),
-        [{ id: 1, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' }, score: 77.77777777777777 }],
+        [{ id: 1, name: { display: 'Avenue', tokenized: [{ token: 'av', token_type: 'Way' }] }, score: 71.42857142857143 }],
         'all-token scenario (e.g. avenue street)');
 
     t.deepEquals(
-        linker([{ tokenized: 'ave st', tokenless: '', display: 'Avenue Street' }], [
-            { id: 1, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' } },
-            { id: 2, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' } },
-            { id: 3, name: { tokenized: 'avenida', tokenless: 'avenida' } }
+        linker([{ tokenized: [{ token: 'av', token_type: 'Way' }, { token: 'st', token_type: 'Way' }], display: 'Avenue Street' }], [
+            { id: 1, name: { tokenized: [{ token: 'av', token_type: 'Way' }], display: 'Avenue' } },
+            { id: 2, name: { tokenized: [{ token: 'av', token_type: 'Way' }], display: 'Avenue' } },
+            { id: 3, name: { tokenized: [{ token: 'avenida', token_type: null }] } }
         ]),
         [
-            { id: 1, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' }, score: 77.77777777777777 },
-            { id: 2, name: { tokenized: 'ave', tokenless: '', display: 'Avenue' }, score: 77.77777777777777 }
+            { id: 1, name: { tokenized: [{ token: 'av', token_type: 'Way' }], display: 'Avenue' }, score: 71.42857142857143 },
+            { id: 2, name: { tokenized: [{ token: 'av', token_type: 'Way' }], display: 'Avenue' }, score: 71.42857142857143 }
         ],
         'multiple winners (exact match)');
 
     t.deepEquals(
-        linker([{ tokenized: 'main st west', tokenless: 'main' }], [
-            { id: 1, name: { tokenized: 'main rd', tokenless: 'main', display: 'Main Road' } },
-            { id: 2, name: { tokenized: 'main av', tokenless: 'main', display: 'Main Avenue' } },
-            { id: 3, name: { tokenized: 'main st', tokenless: 'main', display: 'Main Street' } }
+        linker([{ display: 'Main St West', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Way' }] }], [
+            { id: 1, name: { tokenized: [{ token: 'main', token_type: null }, { token: 'rd', token_type: 'Way' }], display: 'Main Road' } },
+            { id: 2, name: { tokenized: [{ token: 'main', token_type: null }, { token: 'av', token_type: 'Way' }], display: 'Main Avenue' } },
+            { id: 3, name: { tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Main Street' } }
         ]),
-        [{ id: 3, name: { tokenized: 'main st', tokenless: 'main', display: 'Main Street' }, score: 86.84210526315789 }],
+        [{ id: 3, name: { tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Main Street' }, score: 93.75 }],
         'Very Close Matches w/ tokenless');
 
     t.deepEquals(
-        linker([{ display: 'Lake Street West', tokenized: 'lk ts w', tokenless: '' }], [
-            { id: 1, name: { tokenized: 'w lk st', tokenless: '', display: 'West Lake Street' } }
+        linker([{ display: 'Lake Street West', tokenized: [{ token: 'lk', token_type: null }, { token: 'st', token_type: 'Way' }, { token: 'w', token_type: 'Cardinal' }] }], [
+            { id: 1, name: { tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'lk', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Lake Street' } }
         ]),
-        [{ id: 1, name: { tokenized: 'w lk st', tokenless: '', display: 'West Lake Street' }, score: 90.47619047619048 }],
+        [{ id: 1, name: { tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'lk', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Lake Street' }, score: 85.71428571428572 }],
         'Match w/o tokenless');
 
     t.deepEquals(
-        linker([{ tokenized: 'main st', tokenless: '', display: 'Main Street' }], [
-            { id: 1, name: { tokenized: 'maim st', tokenless: 'maim', display: 'Maim Street' } },
-            { id: 2, name: { tokenized: 'maim st', tokenless: 'maim', display: 'Maim Street' } },
-            { id: 3, name: { tokenized: 'cross st', tokenless: 'cross', display: 'Cross Street' } }
+        linker([{ tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Main Street' }], [
+            { id: 1, name: { tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Maim Street' } },
+            { id: 2, name: { tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Maim Street' } },
+            { id: 3, name: { tokenized: [{ token: 'x', token_type: 'Way' }, { token: 'st', token_type: 'Way' }], display: 'Cross Street' } }
         ]),
         [
-            { id: 1, name: { tokenized: 'maim st', tokenless: 'maim', display: 'Maim Street' }, score: 85.71428571428572 },
-            { id: 2, name: { tokenized: 'maim st', tokenless: 'maim', display: 'Maim Street' }, score: 85.71428571428572 }
+            { id: 1, name: { tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Maim Street' }, score: 85.71428571428572 },
+            { id: 2, name: { tokenized: [{ token: 'maim', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'Maim Street' }, score: 85.71428571428572 }
         ],
         'multiple winners (score codepath)');
 
     t.deepEquals(
-        linker([{ tokenized: 's st nw', display: 'S STREET NW', tokenless: null }], [
-            { id: 1250, name: { tokenized: 'p st ne', display: 'P Street Northeast', tokenless: 'p' } },
-            { id: 863, name: { tokenized: 's st nw', display: 'S STREET NW', tokenless: '' } },
-            { id: 862, name: { tokenized: 's st ne', display: 'S STREET NE', tokenless: '' } },
-            { id: 388, name: { tokenized: 'bates st nw', display: 'BATES STREET NW', tokenless: 'bates' } }
+        linker([{ tokenized: [{ token: 's', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'nw', token_type: 'Cardinal' }], display: 'S STREET NW' }], [
+            { id: 1250, name: { tokenized: [{ token: 'p', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'ne', token_type: 'Cardinal' }], display: 'P Street Northeast' } },
+            { id: 863, name: { tokenized: [{ token: 's', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'nw', token_type: 'Cardinal' }], display: 'S STREET NW' } },
+            { id: 862, name: { tokenized: [{ token: 's', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'ne', token_type: 'Cardinal' }], display: 'S STREET NE' } },
+            { id: 388, name: { tokenized: [{ token: 'bates', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'nw', token_type: 'Cardinal' }], display: 'BATES STREET NW' } }
         ]),
-        [{ id: 863, name: { tokenized: 's st nw', display: 'S STREET NW', tokenless: '' }, score: 100 }],
+        [{ id: 863, name: { tokenized: [{ token: 's', token_type: 'Cardinal' }, { token: 'st', token_type: 'Way' }, { token: 'nw', token_type: 'Cardinal' }], display: 'S STREET NW' }, score: 100 }],
         'single winner w/ null tokenless');
 
     t.deepEquals(
-        linker([{ tokenized: 'w main st', display: 'West Main Street', tokenless: 'main' }], [
-            { id: 388, name: { tokenized: 'w st st', display: 'West Saint Street', tokenless: '' } }
+        linker([{ tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Main Street' }], [
+            { id: 388, name: { tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'st', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Saint Street' } }
         ]),
         false,
         'close tokenized');
 
     t.deepEquals(
-        linker([{ tokenized: 'w st st', display: 'West Saint Street', tokenless: '' }], [
-            { id: 388, name: { tokenized: 'w main st', display: 'West Main Street', tokenless: 'main' } }
+        linker([{ tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'st', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Saint Street' }], [
+            { id: 388, name: { tokenized: [{ token: 'w', token_type: 'Cardinal' }, { token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'West Main Street' } }
         ]),
         false,
         'close tokenized reverse');
 
     t.deepEquals(
-        linker([{ tokenized: 's st nw', display: 'S STREET NW', tokenless: null }], [
-            { id: 2421, name: { tokenized: 'n capitol st', display: 'North Capitol Street', tokenless: 'capitol' } },
-            { id: 669, name: { tokenized: 't st ne', display: 'T Street Northeast', tokenless: 't' } },
-            { id: 630, name: { tokenized: 'todd pl ne', display: 'Todd Place Northeast', tokenless: 'todd' } },
-            { id: 1007, name: { tokenized: 'u st ne', display: 'U Street Northeast', tokenless: 'u' } },
-            { id: 2286, name: { tokenized: 'v st ne', display: 'V Street Northeast', tokenless: 'v' } },
-            { id: 1026, name: { tokenized: 'u st nw', display: 'U STREET NW', tokenless: 'u' } },
-            { id: 680, name: { tokenized: 't st nw', display: 'T STREET NW', tokenless: 't' } },
-            { id: 2231, name: { tokenized: 'rhode is av ne', display: 'Rhode Island Avenue Northeast', tokenless: 'rhode' } },
-            { id: 1199, name: { tokenized: 'n capitol st ne', display: 'North Capitol Street Northeast', tokenless: 'capitol' } },
-            { id: 2031, name: { tokenized: 'n capitol st nw', display: 'NORTH CAPITOL STREET NW', tokenless: 'capitol' } },
-            { id: 224, name: { tokenized: 'elm st nw', display: 'Elm Street Northwest', tokenless: 'elm' } },
-            { id: 388, name: { tokenized: 'bates st nw', display: 'BATES STREET NW', tokenless: 'bates' } },
-            { id: 863, name: { tokenized: 's st nw', display: 'S STREET NW', tokenless: '' } },
-            { id: 1365, name: { tokenized: 'rhode is av nw', display: 'RHODE ISLAND AVENUE NW', tokenless: 'rhode' } },
-            { id: 2366, name: { tokenized: 'r st nw', display: 'R STREET NW', tokenless: '' } },
-            { id: 189, name: { tokenized: 'randolph pl ne', display: 'Randolph Place Northeast',tokenless: 'randolph' } },
-            { id: 296, name: { tokenized: 'rt 1', display: 'ROUTE 1', tokenless: '1' } },
-            { id: 629, name: { tokenized: 'lincoln rd ne', display: 'Lincoln Road Northeast', tokenless: 'lincoln' } },
-            { id: 1662, name: { tokenized: 'quincy pl ne', display: 'Quincy Place Northeast', tokenless: 'quincy' } },
-            { id: 852, name: { tokenized: '1st st nw', display: 'First Street Northwest', tokenless: null } },
-            { id: 920, name: { tokenized: 'porter st ne', display: 'Porter Street Northeast', tokenless: 'porter' } },
-            { id: 1037, name: { tokenized: 'quincy pl nw', display: 'Quincy Place Northwest', tokenless: 'quincy' } },
-            { id: 959, name: { tokenized: 'florida av ne', display: 'Florida Avenue Northeast',tokenless: 'florida' } },
-            { id: 969, name: { tokenized: 'richardson pl nw', display: 'Richardson Place Northwest', tokenless: 'richardson' } },
-            { id: 1898, name: { tokenized: '1st st ne', display: 'First Street Northeast', tokenless: null } },
-            { id: 1929, name: { tokenized: 'q st ne', display: 'Q Street Northeast', tokenless: 'q' } },
-            { id: 2053, name: { tokenized: 'florida av nw', display: 'Florida Ave NW', tokenless: 'florida' } },
-            { id: 1250, name: { tokenized: 'p st ne', display: 'P Street Northeast', tokenless: 'p' } },
-            { id: 1243, name: { tokenized: 's st ne', display: 'S Street Northeast', tokenless: null } },
-            { id: 1874, name: { tokenized: 'r st ne', display: 'R Street Northeast', tokenless: null } },
-            { id: 2472, name: { tokenized: 'seaton pl ne', display: 'Seaton Place Northeast', tokenless: 'seaton' } },
-            { id: 1893, name: { tokenized: 'randolph pl nw', display: 'Randolph Place Northwest', tokenless: 'randolph' } },
-            { id: 2074, name: { tokenized: 'anna j cooper cir nw', display: 'Anna J Cooper Circle Northwest', tokenless: 'anna j cooper' } },
-            { id: 69, name: { tokenized: 'p st nw', display: 'P STREET NW', tokenless: 'p' } },
-            { id: 2225, name: { tokenized: 'q st nw', display: 'Q STREET NW', tokenless: 'q' } },
-            { id: 424, name: { tokenized: '4th st nw', display: '4th Street Northwest', tokenless: null } },
-            { id: 761, name: { tokenized: 'v st nw', display: 'V Street Northwest', tokenless: 'v' } },
-            { id: 1210, name: { tokenized: '3rd st nw', display: '3rd Street Northwest', tokenless: null } },
-            { id: 1481, name: { tokenized: 'seaton pl nw', display: 'Seaton Place Northwest', tokenless: 'seaton' } },
-            { id: 460, name: { tokenized: 'flagler pl nw', display: 'Flagler Place Northwest', tokenless: 'flagler' } },
-            { id: 565, name: { tokenized: '2nd st nw', display: '2nd Street Northwest', tokenless: null } },
-            { id: 2402, name: { tokenized: 'thomas st nw', display: 'Thomas Street Northwest', tokenless: 'thomas' } }
+        linker([{ tokenized: [{ token: 's', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'S STREET NW' }], [
+            { id: 2421, name: { tokenized: [{ token: 'n', token_type: 'Cardinal' }, { token: 'capitol', token_type: null }, { token: 'st', token_type: 'Way' }], display: 'North Capitol Street' } },
+            { id: 669, name: { tokenized: [{ token: 't', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'T Street Northeast' } },
+            { id: 630, name: { tokenized: [{ token: 'todd', token_type: null }, { token: 'pl', token_type: null }, { token: 'ne', token_type: null }], display: 'Todd Place Northeast' } },
+            { id: 1007, name: { tokenized: [{ token: 'u', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'U Street Northeast' } },
+            { id: 2286, name: { tokenized: [{ token: 'v', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'V Street Northeast' } },
+            { id: 1026, name: { tokenized: [{ token: 'u', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'U STREET NW' } },
+            { id: 680, name: { tokenized: [{ token: 't', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'T STREET NW' } },
+            { id: 2231, name: { tokenized: [{ token: 'rhode', token_type: null }, { token: 'is', token_type: null }, { token: 'av', token_type: null }, { token: 'ne', token_type: null }], display: 'Rhode Island Avenue Northeast' } },
+            { id: 1199, name: { tokenized: [{ token: 'n', token_type: null }, { token: 'capitol', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'North Capitol Street Northeast' } },
+            { id: 2031, name: { tokenized: [{ token: 'n', token_type: null }, { token: 'capitol', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'NORTH CAPITOL STREET NW' } },
+            { id: 224, name: { tokenized: [{ token: 'elm', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'Elm Street Northwest' } },
+            { id: 388, name: { tokenized: [{ token: 'bates', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'BATES STREET NW' } },
+            { id: 863, name: { tokenized: [{ token: 's', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'S STREET NW' } },
+            { id: 1365, name: { tokenized: [{ token: 'rhode', token_type: null }, { token: 'is', token_type: null }, { token: 'av', token_type: null }, { token: 'nw', token_type: null }], display: 'RHODE ISLAND AVENUE NW' } },
+            { id: 2366, name: { tokenized: [{ token: 'r', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'R STREET NW' } },
+            { id: 189, name: { tokenized: [{ token: 'randolph', token_type: null }, { token: 'pl', token_type: null }, { token: 'ne', token_type: null }], display: 'Randolph Place Northeast' } },
+            { id: 296, name: { tokenized: [{ token: 'rt', token_type: null }, { token: '1', token_type: null }], display: 'ROUTE 1' } },
+            { id: 629, name: { tokenized: [{ token: 'lincoln', token_type: null }, { token: 'rd', token_type: null }, { token: 'ne', token_type: null }], display: 'Lincoln Road Northeast' } },
+            { id: 1662, name: { tokenized: [{ token: 'quincy', token_type: null }, { token: 'pl', token_type: null }, { token: 'ne', token_type: null }], display: 'Quincy Place Northeast' } },
+            { id: 852, name: { tokenized: [{ token: '1st', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'First Street Northwest' } },
+            { id: 920, name: { tokenized: [{ token: 'porter', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'Porter Street Northeast' } },
+            { id: 1037, name: { tokenized: [{ token: 'quincy', token_type: null }, { token: 'pl', token_type: null }, { token: 'nw', token_type: null }], display: 'Quincy Place Northwest' } },
+            { id: 959, name: { tokenized: [{ token: 'florida', token_type: null }, { token: 'av', token_type: null }, { token: 'ne', token_type: null }], display: 'Florida Avenue Northeast' } },
+            { id: 969, name: { tokenized: [{ token: 'richardson', token_type: null }, { token: 'pl', token_type: null }, { token: 'nw', token_type: null }], display: 'Richardson Place Northwest' } },
+            { id: 1898, name: { tokenized: [{ token: '1st', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'First Street Northeast' } },
+            { id: 1929, name: { tokenized: [{ token: 'q', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'Q Street Northeast' } },
+            { id: 2053, name: { tokenized: [{ token: 'florida', token_type: null }, { token: 'av', token_type: null }, { token: 'nw', token_type: null }], display: 'Florida Ave NW' } },
+            { id: 1250, name: { tokenized: [{ token: 'p', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'P Street Northeast' } },
+            { id: 1243, name: { tokenized: [{ token: 's', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'S Street Northeast' } },
+            { id: 1874, name: { tokenized: [{ token: 'r', token_type: null }, { token: 'st', token_type: null }, { token: 'ne', token_type: null }], display: 'R Street Northeast' } },
+            { id: 2472, name: { tokenized: [{ token: 'seaton', token_type: null }, { token: 'pl', token_type: null }, { token: 'ne', token_type: null }], display: 'Seaton Place Northeast' } },
+            { id: 1893, name: { tokenized: [{ token: 'randolph', token_type: null }, { token: 'pl', token_type: null }, { token: 'nw', token_type: null }], display: 'Randolph Place Northwest' } },
+            { id: 2074, name: { tokenized: [{ token: 'anna', token_type: null }, { token: 'j', token_type: null }, { token: 'cooper', token_type: null }, { token: 'cir', token_type: null }, { token: 'nw', token_type: null }], display: 'Anna J Cooper Circle Northwest' } },
+            { id: 69, name: { tokenized: [{ token: 'p', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'P STREET NW' } },
+            { id: 2225, name: { tokenized: [{ token: 'q', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'Q STREET NW' } },
+            { id: 424, name: { tokenized: [{ token: '4th', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: '4th Street Northwest' } },
+            { id: 761, name: { tokenized: [{ token: 'v', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'V Street Northwest' } },
+            { id: 1210, name: { tokenized: [{ token: '3rd', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: '3rd Street Northwest' } },
+            { id: 1481, name: { tokenized: [{ token: 'seaton', token_type: null }, { token: 'pl', token_type: null }, { token: 'nw', token_type: null }], display: 'Seaton Place Northwest' } },
+            { id: 460, name: { tokenized: [{ token: 'flagler', token_type: null }, { token: 'pl', token_type: null }, { token: 'nw', token_type: null }], display: 'Flagler Place Northwest' } },
+            { id: 565, name: { tokenized: [{ token: '2nd', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: '2nd Street Northwest' } },
+            { id: 2402, name: { tokenized: [{ token: 'thomas', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'Thomas Street Northwest' } }
         ]),
-        [{ id: 863, name: { tokenized: 's st nw', display: 'S STREET NW', tokenless: '' }, score: 100 }],
+        [{ id: 863, name: { tokenized: [{ token: 's', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], display: 'S STREET NW' }, score: 100 }],
         'Ensure short circuiting never beats an exact match');
     t.end();
 });
 
 test('Failing Linker Matches', (t) => {
     t.deepEquals(
-        linker([{ display: 'Main Street', tokenized: 'main st' }], [
-            { id: 1, name: { display: 'Anne Boulevard', tokenized: 'anne blvd' } }
+        linker([{ display: 'Main Street', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: null }] }], [
+            { id: 1, name: { display: 'Anne Boulevard', tokenized: [{ token: 'anne', token_type: null }, { token: 'blvd', token_type: null }] } }
         ]),
         false,
         'basic fail');

--- a/test/titlecase.test.js
+++ b/test/titlecase.test.js
@@ -38,32 +38,32 @@ tape('label logic, default behavior', (t) => {
     const label = require('../lib/label/titlecase')();
     const tests = [
         [[
-            { freq: 12, display: 'our lady of whatever', tokenized: 'our lady of whatever', source: 'address' },
-            { freq: 2, display: 'our lady', tokenized: 'our lady', source: 'network' }
+            { freq: 12, display: 'our lady of whatever', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }, { token: 'of', token_type: null }, { token: 'whatever', token_type: null }], source: 'address' },
+            { freq: 2, display: 'our lady', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }], source: 'network' }
         ], 'Our Lady of Whatever,Our Lady'],
         [[
-            { display: 'our lady of whatever', tokenized: 'our lady of whatever', source: 'address' },
-            { display: 'OUR LADY of WHATEVER', tokenized: 'our lady of whatever', source: 'network' }
+            { display: 'our lady of whatever', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }, { token: 'of', token_type: null }, { token: 'whatever', token_type: null }], source: 'address' },
+            { display: 'OUR LADY of WHATEVER', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }, { token: 'of', token_type: null }, { token: 'whatever', token_type: null }], source: 'network' }
         ], 'Our Lady of Whatever'],
         [[
-            { display: 'Our Lady of whatever', tokenized: 'our lady of whatever', source: 'address' },
-            { display: 'OUR LÄDY OF WHATEVER', tokenized: 'our lady of whatever', source: 'network' }
+            { display: 'Our Lady of whatever', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }, { token: 'of', token_type: null }, { token: 'whatever', token_type: null }], source: 'address' },
+            { display: 'OUR LÄDY OF WHATEVER', tokenized: [{ token: 'our', token_type: null }, { token: 'lady', token_type: null }, { token: 'of', token_type: null }, { token: 'whatever', token_type: null }], source: 'network' }
         ], 'Our Lady of Whatever'],
         [[
-            { display: 'York Branch Road', tokenized: 'york br rd', source: 'address' },
-            { display: 'York Road', tokenized: 'york rd', source: 'address' },
-            { display: 'York Road', tokenized: 'york rd', source: 'network' }
+            { display: 'York Branch Road', tokenized: [{ token: 'york', token_type: null }, { token: 'br', token_type: null }, { token: 'rd', token_type: null }], source: 'address' },
+            { display: 'York Road', tokenized: [{ token: 'york', token_type: null }, { token: 'rd', token_type: null }], source: 'address' },
+            { display: 'York Road', tokenized: [{ token: 'york', token_type: null }, { token: 'rd', token_type: null }], source: 'network' }
         ], 'York Road,York Branch Road'],
         [[
-            { 'freq': 603, 'source': 'address', 'display': 'GRAND AVE', 'priority': 0, 'tokenized': 'grand av', 'tokenless': 'grand' },
-            { 'freq': 17, 'source': 'address', 'display': 'GRAND VALLEY DR', 'priority': 0, 'tokenized': 'grand vly dr', 'tokenless': 'grand' },
-            { 'freq': 3, 'source': 'address', 'display': 'Grand Ave', 'priority': 0, 'tokenized': 'grand av', 'tokenless': 'grand' },
-            { 'freq': 1, 'source': 'network', 'display': 'Grand Avenue', 'priority': 0, 'tokenized': 'grand av', 'tokenless': 'grand' }
+            { freq: 603, source: 'address', display: 'GRAND AVE', priority: 0, tokenized: [{ token: 'grand', token_type: null }, { token: 'av', token_type: null }] },
+            { freq: 17, source: 'address', display: 'GRAND VALLEY DR', priority: 0, tokenized: [{ token: 'grand', token_type: null }, { token: 'vly', token_type: null }, { token: 'dr', token_type: null }] },
+            { freq: 3, source: 'address', display: 'Grand Ave', priority: 0, tokenized: [{ token: 'grand', token_type: null }, { token: 'av', token_type: null }] },
+            { freq: 1, source: 'network', display: 'Grand Avenue', priority: 0, tokenized: [{ token: 'grand', token_type: null }, { token: 'av', token_type: null }] }
         ], 'Grand Avenue,Grand Valley Dr'],
         [[
-            { display: 'State Highway 123', tokenized: 'state hwy 123', source: 'address', priority: 1 },
-            { display: 'State Highway 123 ABC', tokenized: 'state hwy 123', source: 'address' }, // Should be deduped on tokenized
-            { display: 'NC 123', tokenized: 'nc 123', source: 'network', priority: 5 }
+            { display: 'State Highway 123', tokenized: [{ token: 'state', token_type: null }, { token: 'hwy', token_type: null }, { token: '123', token_type: null }], source: 'address', priority: 1 },
+            { display: 'State Highway 123 ABC', tokenized: [{ token: 'state', token_type: null }, { token: 'hwy', token_type: null }, { token: '123', token_type: null }], source: 'address' }, // Should be deduped on tokenized
+            { display: 'NC 123', tokenized: [{ token: 'nc', token_type: null }, { token: '123', token_type: null }], source: 'network', priority: 5 }
         ], 'Nc 123,State Highway 123']
     ];
 


### PR DESCRIPTION
## Context

Ref https://github.com/ingalls/pt2itp/issues/457. Updates map's linker module and the titlecase module to use the new `tokenized` format.

Note that some scores in linker.test.js changed because:
- previously `tokenless` was `undefined`
- inconsistent tokenization e.g. cardinals like `west` were sometimes tokenized to `w` and other times left in their unabbreviated form in the `tokenized` property
- incorrect tokenization, e.g. abbreviating `avenue` as `ave` rather than `av`

Tests are currently failing due to changes in the https://github.com/ingalls/pt2itp/pull/466; tests that test the new tokenized format are all passing.

## Next steps
- [ ] review by @ingalls 
- [ ] merge
