### PR TITLE
[phase 3] strict mode

### DIFF
--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -111,7 +111,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                 AND ST_DWithin(ST_SetSRID(ST_Point($2, $3), 4326), p.geom, 0.01);
         ", &[ &addr.number, &addr.geom[0], &addr.geom[1] ]).unwrap();
 
-        let mut potentials: Vec<Address> = Vec::with_capacity(rows.len());
+        let mut persistents: Vec<Address> = Vec::with_capacity(rows.len());
 
         for row in rows.iter() {
             let dist: f64 = row.get(0);
@@ -121,10 +121,10 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
             let paddr: serde_json::Value = row.get(1);
             let paddr = Address::from_value(paddr).unwrap();
-            potentials.push(paddr);
+            persistents.push(paddr);
         }
 
-        match compare(&addr, &mut potentials) {
+        match compare(&addr, &mut persistents) {
             Some(link) => {
                 let link: Vec<&Address> = persistents.iter().filter(|persistent| {
                     if link == persistent.id.unwrap() {
@@ -209,19 +209,19 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 ///
 /// The function will return Some(i64) if the address matches an existing address
 ///
-pub fn compare(primary: &Address, potentials: &mut Vec<Address>) -> Option<i64> {
+pub fn compare(potential: &Address, persistents: &mut Vec<Address>) -> Option<i64> {
     // The address does not exist in the database and should be created
-    if potentials.len() == 0 {
+    if persistents.len() == 0 {
         return None;
     }
 
-    let primary_link = linker::Link::new(0, &primary.names);
+    let potential_link = linker::Link::new(0, &potential.names);
 
-    let potential_links: Vec<linker::Link> = potentials.iter().map(|potential| {
-        linker::Link::new(potential.id.unwrap(), &potential.names)
+    let persistent_links: Vec<linker::Link> = persistents.iter().map(|persistent| {
+        linker::Link::new(persistent.id.unwrap(), &persistent.names)
     }).collect();
 
-    match linker::linker(primary_link, potential_links, true) {
+    match linker::linker(potential_link, persistent_links, true) {
         Some(link) => Some(link.id),
         None => None
     }

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use crate::{Context, text};
 use crate::Tokenized;
+use geocoder_abbreviations::TokenType;
 
 ///
 /// InputName is only used internally to serialize a names array to the
@@ -209,6 +210,16 @@ impl Name {
 
         tokenless
     }
+
+    pub fn has_type(&self, token_type: Option<TokenType>) -> bool {
+        let tokens: Vec<&Tokenized> = self.tokenized
+            .iter()
+            .filter(|x| x.token_type == token_type)
+            .collect();
+
+        tokens.len() > 0
+    }
+
 }
 
 #[cfg(test)]

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -5,6 +5,7 @@ use crate::text::{
 };
 
 use crate::types::Names;
+use geocoder_abbreviations::TokenType;
 
 pub struct Link<'a> {
     pub id: i64,
@@ -50,7 +51,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
             'outer: for potential_name in &potential.names.names {
 
                 // Ensure exact matches are always returned before potential short-circuits
-                // make sure this actually works with objects
                 if name.tokenized == potential_name.tokenized {
                     return Some(LinkResult::new(potential.id, 100.0));
                 }
@@ -68,7 +68,7 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                                     continue 'outer;
                                 }
                             },
-                            Some(_) | None => ()
+                            _ => ()
                         }
                     }
                 }
@@ -563,6 +563,15 @@ mod tests {
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 90.0)));
+        }
+
+        {
+            let a_name = Names::new(vec![Name::new("Main", 0, &context)], &context);
+            let b_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
+
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 86.36)));
         }
 
         {

--- a/test/conflate.test.js
+++ b/test/conflate.test.js
@@ -28,7 +28,7 @@ test('Compare', (t) => {
         context: {
             country: 'us',
             region: 'dc',
-            languages: ['en'],
+            languages: ['en']
         },
         db: 'pt_test'
     }, (err) => {


### PR DESCRIPTION
## Context

Ref https://github.com/ingalls/pt2itp/issues/457. Adds a `strict` mode to linker.rs where we're more stringent with what features are allowed to match. As a first pass, @ingalls and I decided on the following criteria:
- if way tokens exist in both the primary and the potential features, they must match (e.g. `Main Ave` cannot match `Main St` but `Main St` can match `Main`)
- if cardinal tokens exist in both the primary and the potential features, they must match (e.g. `East Main St` cannot match `West Main St` but `East Main St` can match `Main St`)
- in all other cases, we calculate the score just as we normally would

@ingalls I added a few tests for cases I'm not sure how we want to handle:
- where there are multiple cardinals/ways and only some match, e.g. `East Main` vs `North East Main`
- where one feature contains an ordinal and the other a way, e.g. `East Main` vs `Main Street`

Would love your thoughts

## Next steps
- [ ] review by @ingalls 
- [ ] merge
