### PR TITLE
Cardinal Selection

### DIFF
--- a/lib/post/text.js
+++ b/lib/post/text.js
@@ -22,6 +22,7 @@ function post(feat, opts = {}) {
                 feat.properties[k] = feat.properties[k].split(',').splice(0, 10).join(',');
             }
         });
+
     if (feat.properties['carmen:text'].split(',').length === 0) return;
 
     return feat;

--- a/test/titlecase.test.js
+++ b/test/titlecase.test.js
@@ -64,7 +64,11 @@ tape('label logic, default behavior', (t) => {
             { display: 'State Highway 123', tokenized: [{ token: 'state', token_type: null }, { token: 'hwy', token_type: null }, { token: '123', token_type: null }], source: 'address', priority: 1 },
             { display: 'State Highway 123 ABC', tokenized: [{ token: 'state', token_type: null }, { token: 'hwy', token_type: null }, { token: '123', token_type: null }], source: 'address' }, // Should be deduped on tokenized
             { display: 'NC 123', tokenized: [{ token: 'nc', token_type: null }, { token: '123', token_type: null }], source: 'network', priority: 5 }
-        ], 'Nc 123,State Highway 123']
+        ], 'Nc 123,State Highway 123'],
+        [[
+            { freq: 1, display: 'Main St NW', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: null }, { token: 'nw', token_type: null }], source: 'address' },
+            { freq: 600, display: 'Main St', tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: null }], source: 'address', priority: 0 }
+        ], 'Main St NW,Main St']
     ];
 
     for (const test of tests) {


### PR DESCRIPTION
At the moment cardinals are not taken into consideration at titlecase time (the code that selects the primary synonym for a given street feature)

Let's look at a common case:

```
Address (freq: 20): Main St
Network (freq: 1): Main St NW
```

Since there is no override in place for cardinals, the higher frequency in this case will win - resulting in the street having the primary synonym of `Main St`. This PR Changes this behavior in the following circumstances.

- The network has an ordinal and the address doesn't
- There is only 1 cardinal in the feature
  - Considered: `Main St E, Main St`
  - Not Considered: `Main St, W Main ST, Main ST E`

cc/ @lizziegooding @miccolis
