### PR TITLE
Highways

### DIFF
--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -271,6 +271,33 @@ impl Name {
         }
     }
 
+    ///
+    /// Builder style source setter
+    ///
+    /// ie:
+    /// Name::new().set_source("generated")
+    ///
+    /// Can be chained with other builder functions
+    ///
+    pub fn set_source(mut self, source: impl ToString) -> Self {
+        self.source = source.to_string();
+        self
+    }
+
+    ///
+    /// Builder style source setter
+    ///
+    /// ie:
+    /// Name::new().set_freq(1)
+    ///
+    /// Can be chained with other builder functions
+    ///
+    pub fn set_freq(mut self, freq: i64) -> Self {
+        self.freq = freq;
+        self
+    }
+
+
     pub fn tokenized_string(&self) -> String {
         let tokens: Vec<String> = self.tokenized
             .iter()
@@ -432,6 +459,18 @@ mod tests {
 
         assert_eq!(Names::new(vec![Name::new(String::from("Main St NW"), 0, &context)], &context), Names {
             names: vec![Name::new(String::from("Main St NW"), 0, &context)]
+        });
+
+        // Ensure synonyms are being applied correctly
+        assert_eq!(Names::new(vec![Name::new(String::from("US Route 1"), 0, &context)], &context), Names {
+            names: vec![
+                Name::new(String::from("US Route 1"), 0, &context),
+                Name::new(String::from("US 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("US Route 1"), 1, &context).set_source("generated"),
+                Name::new(String::from("US Highway 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("United States Route 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("United States Highway 1"), -1, &context).set_source("generated"),
+            ]
         });
     }
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -472,6 +472,23 @@ mod tests {
                 Name::new(String::from("United States Highway 1"), -1, &context).set_source("generated"),
             ]
         });
+
+        // Ensure highway synonyms are being applied correctly but are downgraded
+        // if the highway is not the highest priority name
+        assert_eq!(Names::new(vec![
+            Name::new(String::from("Main St"), 0, &context),
+            Name::new(String::from("US Route 1"), -1, &context)
+        ], &context), Names {
+            names: vec![
+                Name::new(String::from("Main St"), 0, &context),
+                Name::new(String::from("US Route 1"), -1, &context),
+                Name::new(String::from("US 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("US Route 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("US Highway 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("United States Route 1"), -1, &context).set_source("generated"),
+                Name::new(String::from("United States Highway 1"), -1, &context).set_source("generated"),
+            ]
+        });
     }
 
     #[test]


### PR DESCRIPTION
Allow highways to have their synonym priority level downgraded if they are not determined to be the primary synonym on incoming name features

cc /@lizziegooding