### PR TITLE
Remove whitespace-only names 

### DIFF
--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -88,8 +88,6 @@ impl Address {
 
         let mut names = Names::from_value(street, &context)?;
 
-        names.empty();
-
         if names.names.len() == 0 {
             return Err(String::from("Feature has no valid non-whitespace name"));
         }

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -88,6 +88,12 @@ impl Address {
 
         let mut names = Names::from_value(street, &context)?;
 
+        names.empty();
+
+        if names.names.len() == 0 {
+            return Err(String::from("Feature has no valid non-whitespace name"));
+        }
+
         names.set_source(String::from("address"));
 
         let mut addr = Address {

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -99,6 +99,8 @@ impl Names {
 
         names.names.append(&mut synonyms);
 
+        names.empty();
+
         names
     }
 
@@ -466,6 +468,11 @@ mod tests {
 
         assert_eq!(Names::new(vec![Name::new(String::from("Main St NW"), 0, &context)], &context), Names {
             names: vec![Name::new(String::from("Main St NW"), 0, &context)]
+        });
+
+        // Ensure invalid whitespace-only names are removed
+        assert_eq!(Names::new(vec![Name::new(String::from(""), 0, &context), Name::new(String::from("\t  \n"), 0, &context)], &context), Names {
+            names: Vec::new()
         });
 
         // Ensure synonyms are being applied correctly

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -224,6 +224,13 @@ impl Names {
             }
         }
     }
+
+    ///
+    /// Remove all Name instances where display is whitespace
+    ///
+    pub fn empty(&mut self) {
+        self.names.retain(|name| name.display.trim() != String::from(""));
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -530,5 +537,22 @@ mod tests {
         assert_eq!(Name::new(String::from("foo bar"), 0, &context).has_type(Some(TokenType::Way)), false);
         assert_eq!(Name::new(String::from("foo bar"), 0, &context).has_type(Some(TokenType::Cardinal)), false);
         assert_eq!(Name::new(String::from("foo bar"), 0, &context).has_type(None), true);
+    }
+
+    #[test]
+    fn test_empty() {
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+
+        let mut empty_a = Names::new(vec![Name::new(String::from(""), 0, &context)], &context);
+        empty_a.empty();
+        assert_eq!(empty_a, Names { names: Vec::new() });
+
+        let mut empty_b = Names::new(vec![Name::new(String::from("\t  \n"), 0, &context)], &context);
+        empty_b.empty();
+        assert_eq!(empty_b, Names { names: Vec::new() });
+
+        let mut empty_c = Names::new(vec![Name::new(String::from(""), 0, &context), Name::new(String::from("\t  \n"), 0, &context)], &context);
+        empty_c.empty();
+        assert_eq!(empty_c, Names { names: Vec::new() });
     }
 }

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -67,6 +67,12 @@ impl Network {
 
         let mut names = Names::from_value(street, &context)?;
 
+        names.empty();
+
+        if names.names.len() == 0 {
+            return Err(String::from("Feature has no valid non-whitespace name"));
+        }
+
         names.set_source(String::from("network"));
 
         let mut net = Network {

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -67,8 +67,6 @@ impl Network {
 
         let mut names = Names::from_value(street, &context)?;
 
-        names.empty();
-
         if names.names.len() == 0 {
             return Err(String::from("Feature has no valid non-whitespace name"));
         }


### PR DESCRIPTION
## Context

pt2itp currently doesn't check if a feature contains `Name`s with only whitespace or drop features with no valid non-whitespace names. This PR adds a check within `Names::new()` that only returns non-whitespace `Name`s and returns an error if the `Names` vector is empty when creating address and network features.

cc @ingalls @miccolis @samely 