### PR TITLE
CA_QC Panic

### DIFF
--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -194,7 +194,9 @@ pub fn syn_ca_french(name: &Name, context: &Context) -> Vec<Name> {
     let standalone = vec![String::from("r"), String::from("ch"), String::from("av"), String::from("bd")];
     let eliminator = vec![String::from("du"), String::from("des"), String::from("de")];
 
-    if
+    if name.tokenized.len() <= 1 {
+        return syns;
+    } else if
         standalone.contains(&name.tokenized[0].token)
         && !eliminator.contains(&name.tokenized[1].token)
     {


### PR DESCRIPTION
When building data for `ca_qc` we hit a hard error that prevented the build from completing

```
/usr/local/src/mbpla/node_modules/pt2itp/lib/map.js:118
    import_addr({
    ^

Error: internal error in Neon module: index out of bounds: the len is 1 but the index is 1
    at Object.main [as map] (/usr/local/src/mbpla/node_modules/pt2itp/lib/map.js:118:5)
    at map (/usr/local/src/mbpla/load:375:20)
    at ChildProcess.dbstart.on (/usr/local/src/mbpla/load:361:24)
    at ChildProcess.emit (events.js:189:13)
    at ChildProcess.EventEmitter.emit (domain.js:441:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
```

After extensive debuggin this turned out to be a failure to ensure proper token length in the french synonym generation code.