### PR TITLE
Famous People

### DIFF
--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -402,7 +402,7 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
 
         syns.push(Name::new(format!("MLK Jr{}", &strtype), -1, &context));
         syns.push(Name::new(format!("M L K Jr{}", &strtype), -1, &context));
-        syns.push(Name::new(format!("Martin Luther King Junior{}", &strtype), 1, &context));
+        syns.push(Name::new(format!("Martin Luther King Jr{}", &strtype), 1, &context));
 
     } else if MLK.is_match(name.display.as_str()) {
         let strtype: String = match MLK.captures(name.display.as_str()) {
@@ -652,7 +652,7 @@ mod tests {
         let results = vec![
             Name::new("MLK Jr", -1, &context),
             Name::new("M L K Jr", -1, &context),
-            Name::new("Martin Luther King Junior", 1, &context)
+            Name::new("Martin Luther King Jr", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr"), 0, &context), &context), results);
@@ -667,7 +667,7 @@ mod tests {
         let results = vec![
             Name::new("MLK Jr Highway", -1, &context),
             Name::new("M L K Jr Highway", -1, &context),
-            Name::new("Martin Luther King Junior Highway", 1, &context)
+            Name::new("Martin Luther King Jr Highway", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr Highway"), 0, &context), &context), results);

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -375,9 +375,9 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
     let mut syns: Vec<Name> = Vec::new();
 
     lazy_static! {
-        static ref JFK: Regex = Regex::new(r"(?i)^j(ohn)?\s?f\s?k(ennedy)?(?P<type>\s.*)?$").unwrap();
-        static ref MLK: Regex = Regex::new(r"(?i)^m(artin)?\s?l(uther)?\s?k(ing)?(?P<type>\s.*)?$$").unwrap();
-        static ref MLKJR: Regex = Regex::new(r"(?i)^m(artin)?\s?l(uther)?\s?k(ing)?\s(jr|junior)(?P<type>\s.*)?$$").unwrap();
+        static ref JFK: Regex = Regex::new(r"(?i)^j(\.|ohn)?\s?f(\.)?\s?k(\.|ennedy)?(?P<type>\s.*)?$").unwrap();
+        static ref MLK: Regex = Regex::new(r"(?i)^m(\.|artin)?\s?l(\.|uther)?\s?k(\.|ing)?(?P<type>\s.*)?$$").unwrap();
+        static ref MLKJR: Regex = Regex::new(r"(?i)^m(\.|artin)?\s?l(\.|uther)?\s?k(\.|ing)?\s(jr(\.)?|junior)(?P<type>\s.*)?$$").unwrap();
     }
 
     if JFK.is_match(name.display.as_str()) {
@@ -632,8 +632,11 @@ mod tests {
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("JFK"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J.F.K."), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("J F K"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J. F. K."), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("John F. Kennedy"), 0, &context), &context), results);
 
         let results = vec![
             Name::new("John F Kennedy Highway", 1, &context),
@@ -641,7 +644,9 @@ mod tests {
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("JFK Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J.F.K Highway"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("J F K Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J. F. K. Highway"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy Highway"), 0, &context), &context), results);
 
         let results = vec![
@@ -654,6 +659,8 @@ mod tests {
         assert_eq!(syn_us_famous(&Name::new(String::from("m l king jr"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("m l k jr"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("m l k junior"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m. l. k. jr."), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m. l. k. junior"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Jr"), 0, &context), &context), results);
         assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Junior"), 0, &context), &context), results);
 

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -389,7 +389,7 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
             None => String::from("")
         };
 
-        syns.push(Name::new(format!("John F Kennedy{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("John F Kennedy{}", &strtype), 1, &context));
         syns.push(Name::new(format!("JFK{}", &strtype), -1, &context));
     } else if MLKJR.is_match(name.display.as_str()) {
         let strtype: String = match MLKJR.captures(name.display.as_str()) {
@@ -402,7 +402,7 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
 
         syns.push(Name::new(format!("MLK Jr{}", &strtype), -1, &context));
         syns.push(Name::new(format!("M L K Jr{}", &strtype), -1, &context));
-        syns.push(Name::new(format!("Martin Luther King Junior{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("Martin Luther King Junior{}", &strtype), 1, &context));
 
     } else if MLK.is_match(name.display.as_str()) {
         let strtype: String = match MLK.captures(name.display.as_str()) {
@@ -415,7 +415,7 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
 
         syns.push(Name::new(format!("MLK{}", &strtype), -1, &context));
         syns.push(Name::new(format!("M L K{}", &strtype), -1, &context));
-        syns.push(Name::new(format!("Martin Luther King{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("Martin Luther King{}", &strtype), 1, &context));
     }
 
     syns
@@ -627,7 +627,7 @@ mod tests {
         assert_eq!(syn_us_famous(&Name::new(String::from(""), 0, &context), &context), vec![]);
 
         let results = vec![
-            Name::new("John F Kennedy", -1, &context),
+            Name::new("John F Kennedy", 1, &context),
             Name::new("JFK", -1, &context),
         ];
 
@@ -636,7 +636,7 @@ mod tests {
         assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy"), 0, &context), &context), results);
 
         let results = vec![
-            Name::new("John F Kennedy Highway", -1, &context),
+            Name::new("John F Kennedy Highway", 1, &context),
             Name::new("JFK Highway", -1, &context),
         ];
 
@@ -647,7 +647,7 @@ mod tests {
         let results = vec![
             Name::new("MLK Jr", -1, &context),
             Name::new("M L K Jr", -1, &context),
-            Name::new("Martin Luther King Junior", -1, &context)
+            Name::new("Martin Luther King Junior", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr"), 0, &context), &context), results);
@@ -660,7 +660,7 @@ mod tests {
         let results = vec![
             Name::new("MLK Jr Highway", -1, &context),
             Name::new("M L K Jr Highway", -1, &context),
-            Name::new("Martin Luther King Junior Highway", -1, &context)
+            Name::new("Martin Luther King Junior Highway", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr Highway"), 0, &context), &context), results);
@@ -673,7 +673,7 @@ mod tests {
         let results = vec![
             Name::new("MLK", -1, &context),
             Name::new("M L K", -1, &context),
-            Name::new("Martin Luther King", -1, &context)
+            Name::new("Martin Luther King", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk"), 0, &context), &context), results);
@@ -686,7 +686,7 @@ mod tests {
         let results = vec![
             Name::new("MLK Highway", -1, &context),
             Name::new("M L K Highway", -1, &context),
-            Name::new("Martin Luther King Highway", -1, &context)
+            Name::new("Martin Luther King Highway", 1, &context)
         ];
 
         assert_eq!(syn_us_famous(&Name::new(String::from("mlk Highway"), 0, &context), &context), results);

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -369,6 +369,59 @@ pub fn syn_us_cr(name: &Name, context: &Context) -> Vec<Name> {
 }
 
 ///
+/// Generate synonyms for names like "MLK" => "Martin Luther King"
+///
+pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
+    let mut syns: Vec<Name> = Vec::new();
+
+    lazy_static! {
+        static ref JFK: Regex = Regex::new(r"(?i)^j(ohn)?\s?f\s?k(ennedy)?(?P<type>\s.*)?$").unwrap();
+        static ref MLK: Regex = Regex::new(r"(?i)^m(artin)?\s?l(uther)?\s?k(ing)?(?P<type>\s.*)?$$").unwrap();
+        static ref MLKJR: Regex = Regex::new(r"(?i)^m(artin)?\s?l(uther)?\s?k(ing)?\s(jr|junior)(?P<type>\s.*)?$$").unwrap();
+    }
+
+    if JFK.is_match(name.display.as_str()) {
+        let strtype: String = match JFK.captures(name.display.as_str()) {
+            Some(capture) => match capture.name("type") {
+                Some(name) => name.as_str().to_string(),
+                None => String::from("")
+            },
+            None => String::from("")
+        };
+
+        syns.push(Name::new(format!("John F Kennedy{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("JFK{}", &strtype), -1, &context));
+    } else if MLKJR.is_match(name.display.as_str()) {
+        let strtype: String = match MLKJR.captures(name.display.as_str()) {
+            Some(capture) => match capture.name("type") {
+                Some(name) => name.as_str().to_string(),
+                None => String::from("")
+            },
+            None => String::from("")
+        };
+
+        syns.push(Name::new(format!("MLK Jr{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("M L K Jr{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("Martin Luther King Junior{}", &strtype), -1, &context));
+
+    } else if MLK.is_match(name.display.as_str()) {
+        let strtype: String = match MLK.captures(name.display.as_str()) {
+            Some(capture) => match capture.name("type") {
+                Some(name) => name.as_str().to_string(),
+                None => String::from("")
+            },
+            None => String::from("")
+        };
+
+        syns.push(Name::new(format!("MLK{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("M L K{}", &strtype), -1, &context));
+        syns.push(Name::new(format!("Martin Luther King{}", &strtype), -1, &context));
+    }
+
+    syns
+}
+
+///
 /// Generate synonyms for names like "US 81" => "US Route 81"
 ///
 pub fn syn_us_hwy(name: &Name, context: &Context) -> Vec<Name> {
@@ -565,6 +618,83 @@ mod tests {
             &String::from("McDonalds Drivethru"),
             &context
         ), true);
+    }
+
+    #[test]
+    fn test_syn_us_famous() {
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+
+        assert_eq!(syn_us_famous(&Name::new(String::from(""), 0, &context), &context), vec![]);
+
+        let results = vec![
+            Name::new("John F Kennedy", -1, &context),
+            Name::new("JFK", -1, &context),
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("JFK"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J F K"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy"), 0, &context), &context), results);
+
+        let results = vec![
+            Name::new("John F Kennedy Highway", -1, &context),
+            Name::new("JFK Highway", -1, &context),
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("JFK Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("J F K Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy Highway"), 0, &context), &context), results);
+
+        let results = vec![
+            Name::new("MLK Jr", -1, &context),
+            Name::new("M L K Jr", -1, &context),
+            Name::new("Martin Luther King Junior", -1, &context)
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l king jr"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k jr"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k junior"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Jr"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Junior"), 0, &context), &context), results);
+
+        let results = vec![
+            Name::new("MLK Jr Highway", -1, &context),
+            Name::new("M L K Jr Highway", -1, &context),
+            Name::new("Martin Luther King Junior Highway", -1, &context)
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l king jr Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k jr Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k junior Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Jr Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Junior Highway"), 0, &context), &context), results);
+
+        let results = vec![
+            Name::new("MLK", -1, &context),
+            Name::new("M L K", -1, &context),
+            Name::new("Martin Luther King", -1, &context)
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("mlk"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l king"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King"), 0, &context), &context), results);
+
+        let results = vec![
+            Name::new("MLK Highway", -1, &context),
+            Name::new("M L K Highway", -1, &context),
+            Name::new("Martin Luther King Highway", -1, &context)
+        ];
+
+        assert_eq!(syn_us_famous(&Name::new(String::from("mlk Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l king Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("m l k Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Highway"), 0, &context), &context), results);
+        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Highway"), 0, &context), &context), results);
     }
 
     #[test]

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -88,6 +88,13 @@ impl Tokens {
 
         let tokens: Vec<String> = normalized.split(" ").map(|split| {
             String::from(split)
+        }).filter(|token| {
+            // Remove Empty Tokens (Double Space/Non Trimmed Input)
+            if token.len() == 0 {
+                false
+            } else {
+                true
+            }
         }).collect();
 
         tokens
@@ -166,7 +173,9 @@ mod tests {
         assert_eq!(tokenized_string(tokens.process(&String::from(""))), String::from(""));
 
         assert_eq!(tokenized_string(tokens.process(&String::from("foo"))), String::from("foo"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from(" foo bar"))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo bar "))), String::from("foo bar"));
+        assert_eq!(tokenized_string(tokens.process(&String::from("foo  bar"))), String::from("foo bar"));
         assert_eq!(tokenized_string(tokens.process(&String::from("foo-bar"))), String::from("foo bar"));
         assert_eq!(tokenized_string(tokens.process(&String::from("foo+bar"))), String::from("foo bar"));
         assert_eq!(tokenized_string(tokens.process(&String::from("foo_bar"))), String::from("foo bar"));

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -62,6 +62,8 @@ impl Tokens {
     /// returning a vector of component tokens
     ///
     fn tokenize(&self, text: &String) -> Vec<String> {
+        let text = text.trim();
+
         lazy_static! {
             static ref UP: Regex = Regex::new(r"[\^]+").unwrap();
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -60,6 +60,7 @@ impl Names {
                 highway_synonyms.append(&mut text::syn_state_hwy(&name, &context));
                 highway_synonyms.append(&mut text::syn_us_hwy(&name, &context));
                 highway_synonyms.append(&mut text::syn_us_cr(&name, &context));
+                highway_synonyms.append(&mut text::syn_us_famous(&name, &context));
 
                 if name.priority == top_priority {
                     // Name is high priority - pass through standardized highway names

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -262,7 +262,7 @@ impl Name {
     ///
     /// ```
     pub fn new(display: impl ToString, priority: i8, context: &Context) -> Self {
-        let mut display = display.to_string();
+        let mut display = display.to_string().trim().to_string();
 
         let tokenized = context.tokens.process(&display);
 


### PR DESCRIPTION
MLK/JFK are very common street names and have many common variations. We currently don't support standardizing them. 

Concretely, this query doesn't work; `7474 NE Martin Luther King Junior Blvd, Portland, OR`

However this somewhat cryptic variant works fine; `7474 NE M L King Blvd, Portland, OR`

- mlk
- mlk jr
- m l king
- m l king jr
- Martin Luther King
- Martin Luther King Junior

/cc @ingalls 
